### PR TITLE
Add event container

### DIFF
--- a/containers/Event/__test__/EventContainer.spec.js
+++ b/containers/Event/__test__/EventContainer.spec.js
@@ -1,0 +1,38 @@
+import React              from 'react'
+import { mount, shallow } from 'enzyme'
+import ToJson             from 'enzyme-to-json'
+import { Event }          from '../index.js'
+
+// Mocking the Event component.
+jest.mock('../../../components/Event', () => 'EventComponent',
+  { virtual: true }
+) 
+
+// Mocking the Event action.
+jest.mock('../../../actions/Event', () => 'EventAction',
+  { virtual: true }
+)
+
+const props = {
+  event: {
+    id: 1,
+    name: 'event1',
+    description: 'This is the first event.'
+  },
+  eventId: 1,
+  showEvent: jest.fn()
+}
+
+describe('Event container', () => {
+  it('should call showEvent in componentDidMount once', () => {
+    const wrapper = mount(<Event {...props} />)
+    expect(props.showEvent).toHaveBeenCalledTimes(1)
+    expect(props.showEvent).toBeCalledWith(props.event.id)
+  })
+
+  it('should render self and subcomponents', () => {
+    const wrapper = shallow(<Event {...props} />)
+    const tree = ToJson(wrapper)
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/containers/Event/__test__/EventContainer.spec.js
+++ b/containers/Event/__test__/EventContainer.spec.js
@@ -3,35 +3,9 @@ import { mount, shallow } from 'enzyme'
 import ToJson             from 'enzyme-to-json'
 import { Event }          from '../index.js'
 
-// Mocking the Event component.
-jest.mock('../../../components/Event', () => 'EventComponent',
-  { virtual: true }
-) 
-
-// Mocking the Event action.
-jest.mock('../../../actions/Event', () => 'EventAction',
-  { virtual: true }
-)
-
-const props = {
-  event: {
-    id: 1,
-    name: 'event1',
-    description: 'This is the first event.'
-  },
-  eventId: 1,
-  showEvent: jest.fn()
-}
-
 describe('Event container', () => {
-  it('should call showEvent in componentDidMount once', () => {
-    const wrapper = mount(<Event {...props} />)
-    expect(props.showEvent).toHaveBeenCalledTimes(1)
-    expect(props.showEvent).toBeCalledWith(props.event.id)
-  })
-
   it('should render self and subcomponents', () => {
-    const wrapper = shallow(<Event {...props} />)
+    const wrapper = shallow(<Event/>)
     const tree = ToJson(wrapper)
     expect(tree).toMatchSnapshot()
   })

--- a/containers/Event/__test__/__snapshots__/EventContainer.spec.js.snap
+++ b/containers/Event/__test__/__snapshots__/EventContainer.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Event container should render self and subcomponents 1`] = `
+<EventComponent
+  event={
+    Object {
+      "description": "This is the first event.",
+      "id": 1,
+      "name": "event1",
+    }
+  }
+/>
+`;

--- a/containers/Event/__test__/__snapshots__/EventContainer.spec.js.snap
+++ b/containers/Event/__test__/__snapshots__/EventContainer.spec.js.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Event container should render self and subcomponents 1`] = `
-<EventComponent
-  event={
-    Object {
-      "description": "This is the first event.",
-      "id": 1,
-      "name": "event1",
-    }
-  }
-/>
+<div>
+  This is the Event container.
+</div>
 `;

--- a/containers/Event/index.js
+++ b/containers/Event/index.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import { connect }          from 'react-redux'
+import EventComponent       from '../../components/Event'
+import { showEvent }        from '../../actions/Event'
+
+export class Event extends Component {
+  componentDidMount() {
+    this.props.showEvent(this.props.eventId)
+  }
+
+  render() {
+    return (
+      <EventComponent event={ this.props.event } />
+     )
+  }
+}
+
+const mapStateToProps = (state) => (
+    { event: state.Event.event }
+)
+
+export default connect(mapStateToProps, { showEvent })(Event)

--- a/containers/Event/index.js
+++ b/containers/Event/index.js
@@ -1,22 +1,12 @@
 import React, { Component } from 'react'
 import { connect }          from 'react-redux'
-import EventComponent       from '../../components/Event'
-import { showEvent }        from '../../actions/Event'
 
 export class Event extends Component {
-  componentDidMount() {
-    this.props.showEvent(this.props.eventId)
-  }
-
   render() {
     return (
-      <EventComponent event={ this.props.event } />
+      <div>This is the Event container.</div>
      )
   }
 }
 
-const mapStateToProps = (state) => (
-    { event: state.Event.event }
-)
-
-export default connect(mapStateToProps, { showEvent })(Event)
+export default connect(null)(Event)


### PR DESCRIPTION
### Overview:概要
Event の Container として index.js を containers/Event 配下に追加する。

### Technical changes:技術的変更点
- テストファイルは対象であるEvent Containerのディレクトリ直下の__test__ ディレクトリに格納する
- 旧tebukuro と同様、Container でeventId を受け取り、 componentDidMount メソッドで イベントの詳細を取得するActionを発行する
- Component および Action はテスト時にはモック化する（モック時に ｛virtual: true｝ を指定することでファイルの実体が無くてもモック化が可能）

### Impact point:変更に関する影響箇所
/event にアクセスした場合、Component および Action が存在しないため、現時点ではエラーが出力されイベントページは表示されない

### Change of UserInterface:UIの変更
現時点ではイベントページは正常に表示されないため、スナップショット等の記載なし