### PR TITLE
Fix ESLint errors for importing enzyme in Jest setup file

### DIFF
--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -1,6 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+/* eslint-disable import/no-extraneous-dependencies */
 import { configure } from 'enzyme'
-// eslint-disable-next-line import/no-extraneous-dependencies
 import Adapter from 'enzyme-adapter-react-16'
+/* eslint-disable import/no-extraneous-dependencies */
 
 configure({ adapter: new Adapter() })

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -1,4 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { configure } from 'enzyme'
+// eslint-disable-next-line import/no-extraneous-dependencies
 import Adapter from 'enzyme-adapter-react-16'
 
 configure({ adapter: new Adapter() })


### PR DESCRIPTION
### Overview:概要
#17 のPRにて修正されなかった、Jestのセットアップファイル内でのenzymeのインポートに関するESLintのエラーを修正する。
後述の理由により、当該のインポートについてのチェックを無効にする。

![_003](https://user-images.githubusercontent.com/10824691/31709475-20a58990-b42d-11e7-8707-b99cca38d179.png)

### Technical changes:技術的変更点
.eslintrcファイルでairbnbをextendした場合、devDepandencies からのインポートを禁止するルールが設定される。
Jestのセットアップファイルでは、devDependencies から enzyme パッケージのインポートを行うため、エラーとなる。
このセットアップファイルはテスト時のみ必要で、devDependencies からインポートしても問題ないため、チェックを無効にする。

チェックの無効化設定については、
- .eslintrcファイル内でdevDependencies全体を許可、または特定のファイルについて許可
- 各インポート処理に対してチェックを無効化するコメントを追加

の２つがあるが、今回は１ファイルの２箇所のみ対応が必要なため、後者の対応を行う。

### Impact point:変更に関する影響箇所
なし

### Change of UserInterface:UIの変更
なし