### PR TITLE
Add pre-commit hook to check lint and flow before commmit

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "lint": "eslint . --cache",
     "flow": "flow",
-    "build": "next build && next export"
+    "build": "next build && next export",
+    "precommit": "yarn lint && yarn flow"
   },
   "dependencies": {
     "immutable": "^3.8.2",
@@ -39,6 +40,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "flow-bin": "^0.57.3",
+    "husky": "^0.14.3",
     "jest": "^21.2.1",
     "react-test-renderer": "^16.0.0",
     "redux-mock-store": "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,6 +2931,14 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -4224,6 +4232,10 @@ normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
@@ -5564,6 +5576,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
### Overview:概要
コミット前に構文チェック・型チェックを行うpre-commitフックを追加し、コード品質を保つ。

### Technical changes:技術的変更点
- フックを容易に設定できる、huskyパッケージを追加
- package.jsonにyarn flow、yarn lintを実行するprecommitスクリプトを追加

### Impact point:変更に関する影響箇所
コミットを実行するたびにpre-commitフックが実行され、いずれかのチェックに失敗した場合はコミットが中止される。

### Change of UserInterface:UIの変更
UIの変更はなし

### 補足
pre-commit パッケージもありましたが、使い方が簡単そうなので、husky パッケージにしました。
Next.js プロジェクトでもhusky を採用しているようです。