### PR TITLE
Add fetch event action

### DIFF
--- a/actions/__test__/EventAction.spec.js
+++ b/actions/__test__/EventAction.spec.js
@@ -9,6 +9,7 @@ const middlewares = [promiseMiddleware, thunk]
 const mockStore = configureStore(middlewares)
 let store = Object.create(null)
 
+// Create a mocked router for Nextjs Router instance.
 class MockedRouter {
   constructor() { this.pathname = null }
   replace(pathname) { this.pathname = pathname }
@@ -17,17 +18,22 @@ class MockedRouter {
 Router.router = new MockedRouter()
 
 // TODO: Refactor this mocked function after API implemented.
-// Mocking EventAPI with virtual mode, because API is not implemanted yet.
 jest.mock('../../api/Event', () => ({
-  create: success => (success ? Promise.resolve({ id: 1 }) : Promise.reject(new Error())),
+  create: success => (
+    success ? Promise.resolve({ id: 1 }) : Promise.reject(new Error())
+  ),
+  find: success => (
+    success ? Promise.resolve({ id: 1 }) : Promise.reject(new Error())
+  ),
+  // Mocking EventAPI with virtual mode, because API is not implemanted yet.
 }), { virtual: true })
 
 describe('EventAction', () => {
-  describe('createEvent', () => {
-    beforeEach(() => {
-      store = mockStore({ event: { id: 1 } })
-    })
+  beforeEach(() => {
+    store = mockStore({ event: { id: 1 } })
+  })
 
+  describe('createEvent', () => {
     describe('when successes to create the Event', () => {
       it('returns create action with event data.', () => {
         expect.assertions(2)
@@ -49,12 +55,38 @@ describe('EventAction', () => {
     })
 
     describe('when fails to create the Event', () => {
-      it('returns create action with instance of Error.', async () => {
+      it('returns create action with instance of Error.', () => {
         expect.assertions(2)
         return store.dispatch(Actions.createEvent(false))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.createEvent)
+            expect(action.payload).toBeInstanceOf(Error)
+          })
+      })
+    })
+  })
+
+  describe('fetchEvent', () => {
+    describe('when successes to fetch the Event', () => {
+      it('returns fetch action with event data.', () => {
+        expect.assertions(2)
+        return store.dispatch(Actions.fetchEvent(true))
+          .then(() => {
+            const action = store.getActions()[0]
+            expect(action.type).toBe(ActionsType.Event.fetchEvent)
+            expect(action.payload).toEqual({ id: 1 })
+          })
+      })
+    })
+
+    describe('when fails to fetch the Event', () => {
+      it('returns fetch action with instance of Error.', () => {
+        expect.assertions(2)
+        return store.dispatch(Actions.fetchEvent(false))
+          .then(() => {
+            const action = store.getActions()[0]
+            expect(action.type).toBe(ActionsType.Event.fetchEvent)
             expect(action.payload).toBeInstanceOf(Error)
           })
       })

--- a/actions/event.js
+++ b/actions/event.js
@@ -7,11 +7,10 @@ import ActionsType from '../constants/Actions'
 /* eslint-disable */
 // flow-disable-nextline
 import EventAPI from '../api/Event'
-import type { EventId, EventProps } from '../types/Event'
+import type { EventProps } from '../types/Event'
 
 
 const create = createAction(ActionsType.Event.createEvent, EventAPI.create)
-const fetch = createAction(ActionsType.Event.fetchEvent, EventAPI.find)
 
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => {
     return dispatch(create(params)).then(json => {
@@ -20,6 +19,4 @@ export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState
     })
 }
 
-export const fetchEvent = (params: EventId) => (dispatch: Dispatch) => {
-    return dispatch(fetch(params)).catch(err => { })
-}
+export const fetchEvent = createAction(ActionsType.Event.fetchEvent, EventAPI.find)

--- a/actions/event.js
+++ b/actions/event.js
@@ -7,14 +7,19 @@ import ActionsType from '../constants/Actions'
 /* eslint-disable */
 // flow-disable-nextline
 import EventAPI from '../api/Event'
-import type { EventProps } from '../types/Event'
+import type { EventId, EventProps } from '../types/Event'
 
 
 const create = createAction(ActionsType.Event.createEvent, EventAPI.create)
+const fetch = createAction(ActionsType.Event.fetchEvent, EventAPI.find)
 
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => {
     return dispatch(create(params)).then(json => {
        const id = getState().event.id
        Router.replace(`/event/${id}`)
     })
+}
+
+export const fetchEvent = (params: EventId) => (dispatch: Dispatch) => {
+    return dispatch(fetch(params)).catch(err => { })
 }

--- a/constants/Actions.js
+++ b/constants/Actions.js
@@ -1,6 +1,7 @@
 export default {
   Event: {
     createEvent: 'CREATE_EVENT',
+    fetchEvent: 'FETCH_EVENT',
   },
 }
 

--- a/containers/Event/__test__/EventContainer.spec.js
+++ b/containers/Event/__test__/EventContainer.spec.js
@@ -1,15 +1,40 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import ToJson from 'enzyme-to-json'
 import { Event } from '../index'
 import Params from '../../../factories/Event'
 
 jest.mock('../../../components/Event', () => 'EventComponent')
+// TODO: Remove virtual mode after API implemented.
+jest.mock('../../../api/Event', () => ({
+  find: jest.fn(),
+}), { virtual: true })
+
+let fetchEvent = Object.create(null)
 
 describe('Event container', () => {
+  beforeEach(() => {
+    fetchEvent = jest.fn()
+  })
+
   it('should render self and subcomponents', () => {
-    const wrapper = shallow(<Event event={Params.event1} />)
+    const wrapper = shallow(<Event
+      eventId={Params.event1.id}
+      event={Params.event1}
+      fetchEvent={fetchEvent}
+    />)
     const tree = ToJson(wrapper)
     expect(tree).toMatchSnapshot()
+  })
+
+  it('should call fetchEvent once with correct eventId', () => {
+    mount(<Event
+      eventId={Params.event1.id}
+      event={Params.event1}
+      fetchEvent={fetchEvent}
+    />)
+
+    expect(fetchEvent).toHaveBeenCalledTimes(1)
+    expect(fetchEvent).toBeCalledWith(Params.event1.id)
   })
 })

--- a/containers/Event/index.js
+++ b/containers/Event/index.js
@@ -2,11 +2,11 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { fetchEvent } from '../../actions/event'
-import type { EventId, EventProps } from '../../types/Event'
+import type { EventProps } from '../../types/Event'
 import EventComponent from '../../components/Event'
 
 type Props = {
-  eventId: EventId,
+  eventId: number,
   event: EventProps,
   fetchEvent: Function
 }

--- a/containers/Event/index.js
+++ b/containers/Event/index.js
@@ -1,14 +1,33 @@
 // @flow
-import React from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import type { EventProps } from '../../types/Event'
+import { fetchEvent } from '../../actions/event'
+import type { EventId, EventProps } from '../../types/Event'
 import EventComponent from '../../components/Event'
 
-export const Event = (props: {event: EventProps}) => (
-  <div>
-    This is the Event container.
-    <EventComponent event={props.event} />
-  </div>
-)
+type Props = {
+  eventId: EventId,
+  event: EventProps,
+  fetchEvent: Function
+}
 
-export default connect(null)(Event)
+export class Event extends Component<Props> {
+  componentDidMount() {
+    this.props.fetchEvent(this.props.eventId)
+  }
+
+  render() {
+    return (
+      <div>
+        This is the Event container.
+        <EventComponent event={this.props.event} />
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  event: state.event,
+})
+
+export default connect(mapStateToProps, { fetchEvent })(Event)

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -5,8 +5,5 @@ exports[`Event page renders the event page. 1`] = `
   <h3>
     This is the event page!
   </h3>
-  <Event Container
-    eventId={1}
-  />
 </div>
 `;

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -1,11 +1,8 @@
 // @flow
 import React from 'react'
-import EventContainer from '../../containers/Event'
-import type { EventId } from '../../types/Event'
 
-export default (props: {url: {query: EventId}}) => (
+export default () => (
   <div>
     <h3>This is the event page!</h3>
-    <EventContainer eventId={props.url.query.id} />
   </div>
 )


### PR DESCRIPTION
### Overview:概要
- イベントの詳細を取得する fetchEvent Action を追加
- Event Container に fetchEvent Action を追加して、イベントの詳細データを取得

### Technical changes:技術的変更点
- 実装：
  - Container の componentDidMount（）メソッド内でfetchEvent Actionを呼び出す
  - 本PRによるnetlifyのビルドエラーを避けるため、イベント詳細のページからEvent Containerを一時的に削除
  - 存在しないイベントのIDを指定した場合にエラーページへ表示が必要となるため、[Nextjsのデフォルトのエラーページを利用する](https://github.com/zeit/next.js/#reusing-the-built-in-error-page)前提で、エラーページをContainer内でレンダリングする
  - 上記のエラーページのレンダリング処理にはエラーの存在判定が必要なので、エラーメッセージの形式が決まってから実装したいと考えています

- テスト：
  -  Event Container で fetchEvent Action がイベントIDを引数として、１度呼び出されることを確認

### Impact point:変更に関する影響箇所
fetchEventアクションが追加されるがAPIが存在しないため、イベント詳細のページが表示されなくなる

### Change of UserInterface:UIの変更
イベント詳細のページから一時的にEvent Containerを削除
