### PR TITLE
[WIP] Connect pages to redux

### DIFF
--- a/containers/Event/index.js
+++ b/containers/Event/index.js
@@ -1,14 +1,31 @@
 // @flow
-import React from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import type { EventProps } from '../../types/Event'
 import EventComponent from '../../components/Event'
+import { fetchEvent } from '../../actions/event'
 
-export const Event = (props: {event: EventProps}) => (
-  <div>
-    This is the Event container.
-    <EventComponent event={props.event} />
-  </div>
-)
+type Props = {
+  eventId: number,
+  event: EventProps,
+  fetchEvent: Function
+}
 
-export default connect(null)(Event)
+export class EventContainer extends Component<Props> {
+  componentDidMount() {
+    this.props.fetchEvent(this.props.eventId)
+  }
+
+  render() {
+    return (
+      <div>
+        This is the Event container.
+        <EventComponent event={this.props.event} />
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = state => ({ event: state.event })
+
+export default connect(mapStateToProps, { fetchEvent })(EventContainer)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "immutable": "^3.8.2",
     "next": "^4.0.0",
+    "next-redux-wrapper": "^1.3.4",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",

--- a/pages/event/new.js
+++ b/pages/event/new.js
@@ -1,8 +1,14 @@
 // @flow
 import React from 'react'
+import withRedux from 'next-redux-wrapper'
+import initStore from '../../store'
+import EventFormContainer from '../../containers/EventForm'
 
-export default () => (
+const EventFormPage = () => (
   <div>
     <h3>This is the event form page!</h3>
+    <EventFormContainer />
   </div>
 )
+
+export default withRedux(initStore)(EventFormPage)

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -1,11 +1,15 @@
 // @flow
 import React from 'react'
-import EventContainer from '../../containers/Event'
+import withRedux from 'next-redux-wrapper'
+import initStore from '../../store'
+import Event from '../../containers/Event'
 import type { EventId } from '../../types/Event'
 
-export default (props: {url: {query: EventId}}) => (
+const EventPage = (props: {url: {query: EventId}}) => (
   <div>
     <h3>This is the event page!</h3>
-    <EventContainer eventId={props.url.query.id} />
+    <Event eventId={props.url.query.id} />
   </div>
 )
+
+export default withRedux(initStore)(EventPage)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4071,6 +4071,10 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
+next-redux-wrapper@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-1.3.4.tgz#62de1fbf09d99310ba3d8499cba30816f51b9ecf"
+
 next@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/next/-/next-4.0.3.tgz#ccf66fa79848e49f07125a12fca9f4bf2fcaf904"


### PR DESCRIPTION
### Overview:概要
イベント作成ページとイベント詳細ページを Redux と接続し、一時的に削除していた Container を再度追加する。

### Technical changes:技術的変更点
- Page と Reduxを接続するために、[公式のサンプル](https://github.com/zeit/next.js/tree/master/examples/with-redux)に従い、next-redux-wrapper パッケージを追加

### Impact point:変更に関する影響箇所
本PR により、イベントの作成およびイベント詳細ページの表示が可能となる。

### Change of UserInterface:UIの変更


### Todos
- [x] イベント作成ページ、イベント詳細ページと Redux との接続
- [ ] Reducer・Store追加後の取り込み
- [ ] イベント作成アクションでの、ページ遷移処理の修正
- [ ] エラーメッセージの表示およびエラー画面の追加
- [ ] テストの修正