### PR TITLE
Register Participant of Event

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/node_modules/config-chain/*
 .*/node_modules/npmconf/*
+.*/node_modules/immutable/dist/immutable.js.flow
 
 [include]
 

--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -5,6 +5,13 @@ import Router from 'next/router'
 import * as Actions from '../event'
 import ActionsType from '../../constants/Actions'
 
+jest.mock('../../api/index')
+/* eslint-disable import/first */
+import mockAPI from '../../api/index'
+/* eslint-enable */
+
+const testParam = { id: 1 }
+
 const middlewares = [promiseMiddleware, thunk]
 const mockStore = configureStore(middlewares)
 let store = Object.create(null)
@@ -26,20 +33,9 @@ class MockedRouter {
   }
 }
 
-jest.mock('../../api/index', () => ({
-  event: {
-    create: success => (
-      success ? Promise.resolve({ id: 1 }) : Promise.reject(new Error())
-    ),
-    find: success => (
-      success ? Promise.resolve({ id: 1 }) : Promise.reject(new Error())
-    ),
-  },
-}))
-
 describe('EventAction', () => {
   beforeEach(() => {
-    store = mockStore({ event: { id: 1 } })
+    store = mockStore({ event: testParam })
   })
 
   describe('createEvent', () => {
@@ -48,19 +44,24 @@ describe('EventAction', () => {
     })
 
     describe('when successes to create the Event', () => {
+      beforeEach(() => {
+        /* eslint-disable no-underscore-dangle */
+        mockAPI.__setMockResult(true)
+        /* eslint-enable */
+      })
       it('returns create action with event data.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.createEvent(true))
+        return store.dispatch(Actions.createEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.createEvent)
-            expect(action.payload).toEqual({ id: 1 })
+            expect(action.payload).toEqual(testParam)
           })
       })
 
       it('replace Nextjs routing to event show page.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.createEvent(true))
+        return store.dispatch(Actions.createEvent(testParam))
           .then(() => {
             expect(Router.router.path).toEqual(showEventPath)
             expect(Router.router.asPath).toEqual(showEventAsPath)
@@ -69,9 +70,14 @@ describe('EventAction', () => {
     })
 
     describe('when fails to create the Event', () => {
+      beforeEach(() => {
+        /* eslint-disable no-underscore-dangle */
+        mockAPI.__setMockResult(false)
+        /* eslint-enable */
+      })
       it('returns create action with instance of Error.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.createEvent(false))
+        return store.dispatch(Actions.createEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.createEvent)
@@ -81,7 +87,7 @@ describe('EventAction', () => {
 
       it('keep Nextjs routing path.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.createEvent(false))
+        return store.dispatch(Actions.createEvent(testParam))
           .then(() => {
             expect(Router.router.path).toEqual(newEventPath)
             expect(Router.router.asPath).toEqual(null)
@@ -92,24 +98,70 @@ describe('EventAction', () => {
 
   describe('fetchEvent', () => {
     describe('when successes to fetch the Event', () => {
+      beforeEach(() => {
+        /* eslint-disable no-underscore-dangle */
+        mockAPI.__setMockResult(true)
+        /* eslint-enable */
+      })
       it('returns fetch action with event data.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.fetchEvent(true))
+        return store.dispatch(Actions.fetchEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.fetchEvent)
-            expect(action.payload).toEqual({ id: 1 })
+            expect(action.payload).toEqual(testParam)
           })
       })
     })
 
     describe('when fails to fetch the Event', () => {
+      beforeEach(() => {
+        /* eslint-disable no-underscore-dangle */
+        mockAPI.__setMockResult(false)
+        /* eslint-enable */
+      })
       it('returns fetch action with instance of Error.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.fetchEvent(false))
+        return store.dispatch(Actions.fetchEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.fetchEvent)
+            expect(action.payload).toBeInstanceOf(Error)
+          })
+      })
+    })
+  })
+
+  describe('joinEvent', () => {
+    describe('when successes to join the Event', () => {
+      beforeEach(() => {
+        /* eslint-disable no-underscore-dangle */
+        mockAPI.__setMockResult(true)
+        /* eslint-enable */
+      })
+      it('returns join action with participant data.', () => {
+        expect.assertions(2)
+        return store.dispatch(Actions.joinEvent(testParam))
+          .then(() => {
+            const action = store.getActions()[0]
+            expect(action.type).toBe(ActionsType.Event.joinEvent)
+            expect(action.payload).toEqual(testParam)
+          })
+      })
+    })
+
+    describe('when fails to join the Event', () => {
+      beforeEach(() => {
+        /* eslint-disable no-underscore-dangle */
+        mockAPI.__setMockResult(false)
+        /* eslint-enable */
+      })
+      it('returns join action with instance of Error.', () => {
+        expect.assertions(2)
+        return store.dispatch(Actions.joinEvent(testParam))
+          .then(() => {
+            const action = store.getActions()[0]
+            expect(action.type).toBe(ActionsType.Event.joinEvent)
             expect(action.payload).toBeInstanceOf(Error)
           })
       })

--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -132,7 +132,7 @@ describe('EventAction', () => {
     })
   })
 
-  describe('joinEvent', () => {
+  describe('registerForEvent', () => {
     describe('when successes to join the Event', () => {
       beforeEach(() => {
         /* eslint-disable no-underscore-dangle */
@@ -141,10 +141,10 @@ describe('EventAction', () => {
       })
       it('returns join action with participant data.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.joinEvent(testParam))
+        return store.dispatch(Actions.registerForEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
-            expect(action.type).toBe(ActionsType.Event.joinEvent)
+            expect(action.type).toBe(ActionsType.Event.registerForEvent)
             expect(action.payload).toEqual(testParam)
           })
       })
@@ -158,10 +158,10 @@ describe('EventAction', () => {
       })
       it('returns join action with instance of Error.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.joinEvent(testParam))
+        return store.dispatch(Actions.registerForEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
-            expect(action.type).toBe(ActionsType.Event.joinEvent)
+            expect(action.type).toBe(ActionsType.Event.registerForEvent)
             expect(action.payload).toBeInstanceOf(Error)
           })
       })

--- a/actions/event.js
+++ b/actions/event.js
@@ -3,7 +3,7 @@ import { createAction } from 'redux-actions'
 import Router from 'next/router'
 import type { Dispatch } from 'redux'
 import ActionsType from '../constants/Actions'
-import { event } from '../api'
+import { event, participant } from '../api'
 import type { EventProps } from '../types/Event'
 
 const create = createAction(ActionsType.Event.createEvent, event.create)
@@ -17,3 +17,4 @@ export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState
 )
 
 export const fetchEvent = createAction(ActionsType.Event.fetchEvent, event.find)
+export const joinEvent = createAction(ActionsType.Event.joinEvent, participant.create)

--- a/actions/event.js
+++ b/actions/event.js
@@ -17,4 +17,4 @@ export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState
 )
 
 export const fetchEvent = createAction(ActionsType.Event.fetchEvent, event.find)
-export const joinEvent = createAction(ActionsType.Event.joinEvent, participant.create)
+export const registerForEvent = createAction(ActionsType.Event.registerForEvent, participant.create)

--- a/api/Base.js
+++ b/api/Base.js
@@ -4,8 +4,6 @@ import client from './client'
 import ApiResponseError from './ApiResponseError'
 import ConvertCase from '../utils/ConvertCase'
 
-const toSnakeCase = (params: Object) => ConvertCase.snakeKeysOf(params)
-
 export default class Base {
   endpoints: Object
   client: Object
@@ -35,12 +33,14 @@ export default class Base {
 
   create = (params: Object) => {
     const url = pathToRegexp.compile(this.endpoints.create)(params)
-    return this.client.post(url, toSnakeCase(params)).then(this.onSuccess, this.onFailure)
+    return this.client
+      .post(url, ConvertCase.snakeKeysOf(params)).then(this.onSuccess, this.onFailure)
   }
 
   update = (params: Object) => {
     const url = pathToRegexp.compile(this.endpoints.update)(params)
-    return this.client.post(url, toSnakeCase(params)).then(this.onSuccess, this.onFailure)
+    return this.client
+      .post(url, ConvertCase.snakeKeysOf(params)).then(this.onSuccess, this.onFailure)
   }
 
   delete = (params: number) => {

--- a/api/Base.js
+++ b/api/Base.js
@@ -2,6 +2,9 @@
 import pathToRegexp from 'path-to-regexp'
 import client from './client'
 import ApiResponseError from './ApiResponseError'
+import ConvertCase from '../utils/ConvertCase'
+
+const toSnakeCase = (params: Object) => ConvertCase.snakeKeysOf(params)
 
 export default class Base {
   endpoints: Object
@@ -32,12 +35,12 @@ export default class Base {
 
   create = (params: Object) => {
     const url = pathToRegexp.compile(this.endpoints.create)(params)
-    return this.client.post(url, params).then(this.onSuccess, this.onFailure)
+    return this.client.post(url, toSnakeCase(params)).then(this.onSuccess, this.onFailure)
   }
 
   update = (params: Object) => {
     const url = pathToRegexp.compile(this.endpoints.update)(params)
-    return this.client.post(url, params).then(this.onSuccess, this.onFailure)
+    return this.client.post(url, toSnakeCase(params)).then(this.onSuccess, this.onFailure)
   }
 
   delete = (params: number) => {

--- a/api/Participant.js
+++ b/api/Participant.js
@@ -1,0 +1,5 @@
+// @flow
+import Base from './Base'
+
+export default class Participant extends Base {
+}

--- a/api/__mocks__/index.js
+++ b/api/__mocks__/index.js
@@ -1,0 +1,29 @@
+const api = jest.genMockFromModule('../index')
+
+let mockResult = Object.create(null)
+/* eslint-disable no-underscore-dangle */
+export const __setMockResult = (normal = true) => {
+  mockResult = normal
+}
+/* eslint-enable */
+
+const mockedPromise = params => (
+  mockResult ? Promise.resolve(params) : Promise.reject(new Error())
+)
+
+export const event = {
+  create: mockedPromise,
+  find: mockedPromise,
+}
+
+export const participant = {
+  create: mockedPromise,
+}
+
+/* eslint-disable no-underscore-dangle */
+api.__setMockResult = __setMockResult
+/* eslint-enable */
+api.event = event
+api.participant = participant
+
+export default api

--- a/api/__tests__/Base.spec.js
+++ b/api/__tests__/Base.spec.js
@@ -27,6 +27,7 @@ describe('Base', () => {
   describe('.all', () => {
     describe('on success', () => {
       it('should return all mock data.', () => {
+        expect.assertions(1)
         moxios.stubOnce('get', baseUrl, { status: 200, response: events })
         return base.all().then((res) => {
           expect(res).toEqual(events)
@@ -38,6 +39,7 @@ describe('Base', () => {
   describe('.create', () => {
     describe('on success', () => {
       it('should return created mock data.', () => {
+        expect.assertions(1)
         moxios.stubOnce('post', baseUrl, { status: 201, response: event1 })
         return base.create(event1).then((res) => {
           expect(res).toEqual(event1)
@@ -46,6 +48,7 @@ describe('Base', () => {
     })
     describe('on failure', () => {
       it('should return Error object with messages.', () => {
+        expect.assertions(1)
         moxios.stubOnce('post', baseUrl, {
           status: 422,
           response: { name: ['を入力してください', 'は８文字以上です'] },
@@ -60,6 +63,7 @@ describe('Base', () => {
   describe('.find', () => {
     describe('on success', () => {
       it('should return find mock data.', () => {
+        expect.assertions(1)
         moxios.stubOnce('get', detailUrl, { status: 200, response: event1 })
         return base.find(event1).then((res) => {
           expect(res).toEqual(event1)
@@ -68,6 +72,7 @@ describe('Base', () => {
     })
     describe('on failure', () => {
       it('should return Error object with messages.', () => {
+        expect.assertions(1)
         moxios.stubOnce('get', detailUrl, { status: 404 })
         return base.find(event1).catch((err) => {
           expect(err.errors).toEqual(['Not Found'])
@@ -79,6 +84,7 @@ describe('Base', () => {
   describe('.update', () => {
     describe('on success', () => {
       it('should return update mock data.', () => {
+        expect.assertions(1)
         moxios.stubOnce('post', detailUrl, { status: 200, response: event1 })
         return base.update(event1).then((res) => {
           expect(res).toEqual(event1)
@@ -87,6 +93,7 @@ describe('Base', () => {
     })
     describe('on failure', () => {
       it('should return Error object with messages.', () => {
+        expect.assertions(1)
         moxios.stubOnce('post', detailUrl, {
           status: 422,
           response: { name: ['を入力してください', 'は８文字以上です'] },
@@ -101,6 +108,7 @@ describe('Base', () => {
   describe('.delete', () => {
     describe('on success', () => {
       it('should return deleted mock data.', () => {
+        expect.assertions(1)
         moxios.stubOnce('delete', detailUrl, { status: 200, response: event1 })
         return base.delete(event1).then((res) => {
           expect(res).toEqual(event1)
@@ -109,6 +117,7 @@ describe('Base', () => {
     })
     describe('on failure', () => {
       it('should return Error object with messages.', () => {
+        expect.assertions(1)
         moxios.stubOnce('delete', detailUrl, { status: 404 })
         return base.delete(event1).catch((err) => {
           expect(err.errors).toEqual(['Not Found'])

--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,7 @@
 // @flow
 import Event from './Event'
+import Participant from './Participant'
 import * as endpoints from '../constants/endpoints'
 
-// eslint-disable-next-line
 export const event = new Event(endpoints.event)
+export const participant = new Participant(endpoints.participant)

--- a/components/EventForm/index.js
+++ b/components/EventForm/index.js
@@ -14,7 +14,6 @@ export default class EventForm extends Component<Props, State> {
   }
 
   onChangeHandler = (e: SyntheticInputEvent<>) => {
-    e.preventDefault()
     this.setState({
       ...this.state,
       [e.target.id]: e.target.value,
@@ -26,6 +25,7 @@ export default class EventForm extends Component<Props, State> {
     this.props.onSubmit(this.state)
   }
 
+  // TODO: Extract component and fields as common components
   render() {
     return (
       <div>

--- a/components/ParticipantForm/__test__/ParticipantForm.spec.js
+++ b/components/ParticipantForm/__test__/ParticipantForm.spec.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import shallowToJson from 'enzyme-to-json'
+import ParticipantForm from '../index'
+
+const inputValues = {
+  name: 'participant1',
+}
+
+const testProps = {
+  eventId: 1,
+}
+
+
+describe('ParticipantForm', () => {
+  it('renders participant form component', () => {
+    const wrapper = shallow(<ParticipantForm {...testProps} onSubmit={jest.fn()} />)
+    const tree = shallowToJson(wrapper)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  describe('when submit', () => {
+    describe('with correct argument', () => {
+      const onSubmit = jest.fn()
+      const wrapper = mount(<ParticipantForm {...testProps} onSubmit={onSubmit} />)
+
+      const nameElement = wrapper.find('[type="text"]')
+
+      nameElement.simulate(
+        'change',
+        { target: { id: 'name', value: inputValues.name } },
+      )
+      wrapper.find('[type="submit"]').simulate('submit')
+
+      it('should call onSubmit once.', () => {
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+      })
+
+      it('should call onSubmit with correct argument.', () => {
+        expect(onSubmit).toBeCalledWith({ ...inputValues, ...testProps })
+      })
+    })
+  })
+})

--- a/components/ParticipantForm/__test__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__test__/__snapshots__/ParticipantForm.spec.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ParticipantForm renders participant form component 1`] = `
+<div>
+  <h3>
+    Event participation form
+  </h3>
+  <form
+    onSubmit={[Function]}
+  >
+    <div>
+      <label
+        htmlFor="name"
+      >
+        name
+        <input
+          id="name"
+          onChange={[Function]}
+          type="text"
+          value=""
+        />
+      </label>
+    </div>
+    <div>
+      <input
+        type="submit"
+      />
+    </div>
+  </form>
+</div>
+`;

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -1,0 +1,53 @@
+// @flow
+import React, { Component } from 'react'
+
+type Props = {
+  onSubmit: Function,
+  eventId: ?number,
+}
+type State = {
+  name: string,
+  eventId: ?number,
+}
+
+export default class ParticipantForm extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      name: '',
+      eventId: props.eventId,
+    }
+  }
+
+  onChangeHandler = (e: SyntheticInputEvent<>) => {
+    e.preventDefault()
+    this.setState({
+      ...this.state,
+      [e.target.id]: e.target.value,
+    })
+  }
+
+  onSubmitHandler = (e: SyntheticEvent<>) => {
+    e.preventDefault()
+    this.props.onSubmit(this.state)
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>Event participation form</h3>
+        <form onSubmit={this.onSubmitHandler}>
+          <div>
+            <label htmlFor="name">
+              name
+              <input type="text" id="name" value={this.state.name} onChange={this.onChangeHandler} />
+            </label>
+          </div>
+          <div>
+            <input type="submit" />
+          </div>
+        </form>
+      </div>
+    )
+  }
+}

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -20,7 +20,6 @@ export default class ParticipantForm extends Component<Props, State> {
   }
 
   onChangeHandler = (e: SyntheticInputEvent<>) => {
-    e.preventDefault()
     this.setState({
       ...this.state,
       [e.target.id]: e.target.value,
@@ -32,6 +31,7 @@ export default class ParticipantForm extends Component<Props, State> {
     this.props.onSubmit(this.state)
   }
 
+  // TODO: Extract component and fields as common components
   render() {
     return (
       <div>

--- a/constants/Actions.js
+++ b/constants/Actions.js
@@ -2,7 +2,7 @@ export default {
   Event: {
     createEvent: 'CREATE_EVENT',
     fetchEvent: 'FETCH_EVENT',
-    joinEvent: 'JOIN_EVENT',
+    registerForEvent: 'REGISTER_FOR_EVENT',
   },
 }
 

--- a/constants/Actions.js
+++ b/constants/Actions.js
@@ -2,6 +2,7 @@ export default {
   Event: {
     createEvent: 'CREATE_EVENT',
     fetchEvent: 'FETCH_EVENT',
+    joinEvent: 'JOIN_EVENT',
   },
 }
 

--- a/constants/endpoints.js
+++ b/constants/endpoints.js
@@ -1,8 +1,11 @@
-// eslint-disable-next-line
 export const event = {
   all: '/events',
   find: '/events/:id',
   create: '/events',
   update: '/events/:id',
   delete: '/events/:id',
+}
+
+export const participant = {
+  create: '/events/:eventId/participants',
 }

--- a/factories/Participant.js
+++ b/factories/Participant.js
@@ -1,0 +1,10 @@
+export default {
+  participant1: {
+    id: 1,
+    eventId: 1,
+    name: 'participant1',
+  },
+  errorParticipant: {
+    errors: ['nameを入力してください', 'nameは１０文字以内です'],
+  },
+}

--- a/models/Base.js
+++ b/models/Base.js
@@ -1,0 +1,12 @@
+// @flow
+import { Record } from 'immutable'
+
+export default (args: Object = {}) => {
+  const base = Record({ errors: [], ...args })
+
+  return class BaseClass extends base {
+    isError() {
+      return this.errors.length !== 0
+    }
+  }
+}

--- a/models/Event.js
+++ b/models/Event.js
@@ -1,0 +1,16 @@
+// @flow
+import { Set } from 'immutable'
+import Record from './Base'
+
+export const EventRecord = Record({
+  id: 0,
+  name: '',
+  description: '',
+  participants: Set.of(),
+})
+
+export default class Event extends EventRecord {
+  setParticipants(list: ?Object[]) {
+    return this.set('participants', Set.of(...list))
+  }
+}

--- a/models/Participant.js
+++ b/models/Participant.js
@@ -1,0 +1,10 @@
+// @flow
+import Record from './Base'
+
+export const ParticipantRecord = Record({
+  id: 0,
+  name: '',
+})
+
+export default class Participant extends ParticipantRecord {
+}

--- a/models/__test__/Base.spec.js
+++ b/models/__test__/Base.spec.js
@@ -1,0 +1,24 @@
+import Base from '../Base'
+
+const subjectClass = (params) => {
+  const Klass = Base(params)
+  return new Klass()
+}
+
+describe('Base', () => {
+  describe('isError', () => {
+    describe('when error is not empty', () => {
+      it('should return true', () => {
+        const subject = subjectClass({ errors: ['error'] })
+        expect(subject.isError()).toBe(true)
+      })
+    })
+
+    describe('when error is empty', () => {
+      it('should return false', () => {
+        const subject = subjectClass({ errors: [] })
+        expect(subject.isError()).toBe(false)
+      })
+    })
+  })
+})

--- a/models/__test__/Event.spec.js
+++ b/models/__test__/Event.spec.js
@@ -1,0 +1,16 @@
+import { Set } from 'immutable'
+import Event from '../Event'
+import ParticipantParams from '../../factories/Participant'
+
+describe('Event', () => {
+  describe('setParticipants', () => {
+    it('should set given array of patricipants.', () => {
+      const event = new Event()
+      const participants = [ParticipantParams.participant1]
+
+      const subject = event.setParticipants(participants)
+
+      expect(subject.participants).toEqual(Set.of(...participants))
+    })
+  })
+})

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,10 @@
+// @flow
+import { EventRecord } from '../models/Event'
+import { ParticipantRecord } from '../models/Participant'
+
+const Records = [
+  EventRecord,
+  ParticipantRecord,
+]
+
+export default Records

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
   "dependencies": {
     "axios": "^0.16.2",
     "immutable": "^3.8.2",
+    "lodash": "^4.17.4",
     "next": "^4.0.0",
-    "path-to-regexp": "^2.0.0",
     "next-redux-wrapper": "^1.3.4",
+    "path-to-regexp": "^2.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -26,3 +26,32 @@ exports[`ShowEvent renders the page not found error page. 1`] = `
   statusCode="404"
 />
 `;
+
+exports[`ShowEvent renders the page with error messages. 1`] = `
+<div>
+  <ul>
+    <li>
+      nameを入力してください
+    </li>
+    <li>
+      nameは１０文字以内です
+    </li>
+  </ul>
+  <h3>
+    This is the event page!
+  </h3>
+  <EventComponent
+    event={
+      Object {
+        "errors": Array [
+          "nameを入力してください",
+          "nameは１０文字以内です",
+        ],
+      }
+    }
+  />
+  <ParticipantForm
+    onSubmit={[Function]}
+  />
+</div>
+`;

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -14,6 +14,10 @@ exports[`ShowEvent renders the event page. 1`] = `
       }
     }
   />
+  <ParticipantForm
+    eventId={1}
+    onSubmit={[Function]}
+  />
 </div>
 `;
 

--- a/pageTests/event/show.spec.js
+++ b/pageTests/event/show.spec.js
@@ -12,6 +12,7 @@ const testProps = {
   url: { query: { id: Params.event1.id } },
   event: Params.event1,
   fetchEvent: jest.fn(),
+  joinEvent: jest.fn(),
 }
 
 describe('ShowEvent', () => {
@@ -26,8 +27,16 @@ describe('ShowEvent', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('renders the page not found error page.', () => {
+  it('renders the page with error messages.', () => {
     const errorTestProps = { ...testProps, event: Params.errorEvent }
+    const page = shallow(<ShowEvent {...errorTestProps} />)
+    const tree = shallowToJson(page)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders the page not found error page.', () => {
+    const errorTestProps = { ...testProps, event: { errors: ['Not Found'] } }
     const page = shallow(<ShowEvent {...errorTestProps} />)
     const tree = shallowToJson(page)
 

--- a/pageTests/event/show.spec.js
+++ b/pageTests/event/show.spec.js
@@ -12,7 +12,7 @@ const testProps = {
   url: { query: { id: Params.event1.id } },
   event: Params.event1,
   fetchEvent: jest.fn(),
-  joinEvent: jest.fn(),
+  registerForEvent: jest.fn(),
 }
 
 describe('ShowEvent', () => {

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import withRedux from 'next-redux-wrapper'
 import Error from 'next/error'
 import createStore from '../../store'
-import { fetchEvent, joinEvent } from '../../actions/event'
+import { fetchEvent, registerForEvent } from '../../actions/event'
 import type { EventId, EventProps } from '../../types/Event'
 import EventComponent from '../../components/Event'
 import ParticipantFormComponent from '../../components/ParticipantForm'
@@ -12,7 +12,7 @@ type Props = {
   url: { query: EventId },
   event: EventProps,
   fetchEvent: Function,
-  joinEvent: Function,
+  registerForEvent: Function,
 }
 
 export class ShowEvent extends Component<Props> {
@@ -41,7 +41,7 @@ export class ShowEvent extends Component<Props> {
         <h3>This is the event page!</h3>
         <EventComponent event={event} />
         <ParticipantFormComponent
-          onSubmit={this.props.joinEvent}
+          onSubmit={this.props.registerForEvent}
           eventId={this.props.event.id}
         />
       </div>
@@ -53,7 +53,7 @@ const mapStateToProps = state => ({
   event: state.event,
 })
 
-const mapDispatchToProps = { fetchEvent, joinEvent }
+const mapDispatchToProps = { fetchEvent, registerForEvent }
 
 const connectProps = {
   createStore,

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -6,6 +6,7 @@ import createStore from '../../store'
 import { fetchEvent } from '../../actions/event'
 import type { EventId, EventProps } from '../../types/Event'
 import EventComponent from '../../components/Event'
+import ParticipantFormComponent from '../../components/ParticipantForm'
 
 type Props = {
   url: { query: EventId },
@@ -28,6 +29,7 @@ export class ShowEvent extends Component<Props> {
       <div>
         <h3>This is the event page!</h3>
         <EventComponent event={this.props.event} />
+        <ParticipantFormComponent onSubmit={() => {}} eventId={this.props.event.id} />
       </div>
     )
   }

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import withRedux from 'next-redux-wrapper'
 import Error from 'next/error'
 import createStore from '../../store'
-import { fetchEvent } from '../../actions/event'
+import { fetchEvent, joinEvent } from '../../actions/event'
 import type { EventId, EventProps } from '../../types/Event'
 import EventComponent from '../../components/Event'
 import ParticipantFormComponent from '../../components/ParticipantForm'
@@ -12,6 +12,7 @@ type Props = {
   url: { query: EventId },
   event: EventProps,
   fetchEvent: Function,
+  joinEvent: Function,
 }
 
 export class ShowEvent extends Component<Props> {
@@ -20,16 +21,29 @@ export class ShowEvent extends Component<Props> {
     this.props.fetchEvent(eventId)
   }
 
+  isNotFoundError(errors: ?string[]) {
+    return errors && errors[0] === 'Not Found'
+  }
+
   render() {
-    if (this.props.event.errors) {
+    const { event } = this.props
+    if (this.isNotFoundError(event.errors)) {
       return <Error statusCode="404" />
     }
 
     return (
       <div>
+        { event.errors &&
+          <ul>
+            { event.errors.map(error => <li>{ error }</li>) }
+          </ul>
+        }
         <h3>This is the event page!</h3>
-        <EventComponent event={this.props.event} />
-        <ParticipantFormComponent onSubmit={() => {}} eventId={this.props.event.id} />
+        <EventComponent event={event} />
+        <ParticipantFormComponent
+          onSubmit={this.props.joinEvent}
+          eventId={this.props.event.id}
+        />
       </div>
     )
   }
@@ -39,7 +53,7 @@ const mapStateToProps = state => ({
   event: state.event,
 })
 
-const mapDispatchToProps = { fetchEvent }
+const mapDispatchToProps = { fetchEvent, joinEvent }
 
 const connectProps = {
   createStore,

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -2,7 +2,9 @@ import { createAction } from 'redux-actions'
 import EventReducer, { eventInitialState } from '../event'
 import Actions from '../../constants/Actions'
 import EventParams from '../../factories/Event'
+import ParticipantParams from '../../factories/Participant'
 import ApiResponseError from '../../api/ApiResponseError'
+import ConvertCase from '../../utils/ConvertCase'
 
 const error = {
   response: { data: { name: ['を入力して下さい', 'は１０文字以下です'] } },
@@ -48,6 +50,30 @@ describe('Event Reducer', () => {
     describe('with failure event fetch', () => {
       it('should return error message', () => {
         const eventState = EventReducer(null, fetchEvent(new ApiResponseError(error)))
+        expect(eventState.errors).toEqual(errorMessages)
+      })
+    })
+  })
+
+  describe('when JOIN_EVENT action', () => {
+    const joinEvent = createAction(Actions.Event.joinEvent)
+
+    const participant = ParticipantParams.participant1
+    const receivedData = ConvertCase.snakeKeysOf(participant)
+
+    const prevStateParams = { ...EventParams.event1, participants: [] }
+    const nextStateParams = { ...EventParams.event1, participants: [participant] }
+
+    describe('with success event join', () => {
+      it('should return joined event', () => {
+        const eventState = EventReducer(prevStateParams, joinEvent(receivedData))
+        expect(eventState).toEqual(nextStateParams)
+      })
+    })
+
+    describe('with failure event join', () => {
+      it('should return error message', () => {
+        const eventState = EventReducer(prevStateParams, joinEvent(new ApiResponseError(error)))
         expect(eventState.errors).toEqual(errorMessages)
       })
     })

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -63,7 +63,7 @@ describe('Event Reducer', () => {
   })
 
   describe('when JOIN_EVENT action', () => {
-    const joinEvent = createAction(Actions.Event.joinEvent)
+    const registerForEvent = createAction(Actions.Event.registerForEvent)
 
     const participant = ParticipantParams.participant1
     const receivedData = ConvertCase.snakeKeysOf(participant)
@@ -79,14 +79,14 @@ describe('Event Reducer', () => {
 
     describe('with success event join', () => {
       it('should return joined event', () => {
-        const eventState = EventReducer(prevState, joinEvent(receivedData))
+        const eventState = EventReducer(prevState, registerForEvent(receivedData))
         expect(eventState).toEqual(nextState)
       })
     })
 
     describe('with failure event join', () => {
       it('should return error message', () => {
-        const eventState = EventReducer(prevState, joinEvent(new ApiResponseError(error)))
+        const eventState = EventReducer(prevState, registerForEvent(new ApiResponseError(error)))
         expect(eventState).toEqual(prevState.set('errors', errorMessages))
       })
     })

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -22,7 +22,7 @@ const eventReducerMap = {
     ),
   },
 
-  [Actions.Event.joinEvent]: {
+  [Actions.Event.registerForEvent]: {
     next: (state, action) => {
       const participant = new ParticipantModel(ConvertCase.camelKeysOf(action.payload))
       // Clear error message of previous error.

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -1,6 +1,7 @@
 // @flow
 import { handleActions } from 'redux-actions'
 import Actions from '../constants/Actions'
+import ConvertCase from '../utils/ConvertCase'
 
 export const eventInitialState = {}
 
@@ -16,6 +17,19 @@ const eventReducerMap = {
     next: (state, action) => action.payload,
     throw: (state, action) => (
       { errors: action.payload.errors }
+    ),
+  },
+
+  [Actions.Event.joinEvent]: {
+    next: (state, action) => {
+      const partricipant = ConvertCase.camelKeysOf(action.payload)
+      return {
+        ...state,
+        participants: [...state.participants, partricipant],
+      }
+    },
+    throw: (state, action) => (
+      { ...state, errors: action.payload.errors }
     ),
   },
 }

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -1,35 +1,37 @@
 // @flow
 import { handleActions } from 'redux-actions'
 import Actions from '../constants/Actions'
+import EventModel from '../models/Event'
+import ParticipantModel from '../models/Participant'
 import ConvertCase from '../utils/ConvertCase'
 
-export const eventInitialState = {}
+export const eventInitialState = new EventModel()
 
 const eventReducerMap = {
   [Actions.Event.createEvent]: {
-    next: (state, action) => action.payload,
+    next: (state, action) => new EventModel(action.payload),
     throw: (state, action) => (
-      { errors: action.payload.errors }
+      new EventModel({ errors: action.payload.errors })
     ),
   },
 
   [Actions.Event.fetchEvent]: {
-    next: (state, action) => action.payload,
+    next: (state, action) => new EventModel(action.payload),
     throw: (state, action) => (
-      { errors: action.payload.errors }
+      new EventModel({ errors: action.payload.errors })
     ),
   },
 
   [Actions.Event.joinEvent]: {
     next: (state, action) => {
-      const partricipant = ConvertCase.camelKeysOf(action.payload)
-      return {
-        ...state,
-        participants: [...state.participants, partricipant],
-      }
+      const participant = new ParticipantModel(ConvertCase.camelKeysOf(action.payload))
+      // Clear error message of previous error.
+      const event = state.set('errors', [])
+
+      return event.setParticipants([...state.get('participants'), participant])
     },
     throw: (state, action) => (
-      { ...state, errors: action.payload.errors }
+      state.set('errors', action.payload.errors)
     ),
   },
 }

--- a/store/index.js
+++ b/store/index.js
@@ -2,6 +2,9 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import promiseMiddleware from 'redux-promise'
 import thunkMiddleware from 'redux-thunk'
+
+import Immutable from 'immutable'
+import Records from '../models'
 import Reducers from '../reducers'
 
 export default (initialState: Object = {}) => {
@@ -10,7 +13,12 @@ export default (initialState: Object = {}) => {
     process.env.NODE_ENV !== 'production' &&
     typeof window === 'object' &&
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
-      window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : compose
+      window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+        serialize: {
+          immutable: Immutable,
+          refs: Records,
+        },
+      }) : compose
   /* eslint-enable */
 
   const middlewares = [promiseMiddleware, thunkMiddleware]

--- a/types/Event.js
+++ b/types/Event.js
@@ -5,6 +5,7 @@ export type EventId = {
 }
 
 export type EventProps = {
+  id: ?number,
   name: string,
   description: string,
   errors: ?string[]

--- a/utils/ConvertCase.js
+++ b/utils/ConvertCase.js
@@ -1,0 +1,18 @@
+// @flow
+import _ from 'lodash'
+
+const convertKeys = (dict, converter) => (
+  _.mapKeys(dict, (v, k) => converter(k))
+)
+
+const ConvertCase = {
+  camelKeysOf(dict: Object) {
+    return convertKeys(dict, _.camelCase)
+  },
+
+  snakeKeysOf(dict: Object) {
+    return convertKeys(dict, _.snakeCase)
+  },
+}
+
+export default ConvertCase

--- a/utils/__test__/ConvertCase.spec.js
+++ b/utils/__test__/ConvertCase.spec.js
@@ -1,0 +1,25 @@
+import ConvertCase from '../ConvertCase'
+
+describe('ConvertCase', () => {
+  const camelKeysParams = {
+    eventId: 1,
+    name: 'name',
+  }
+
+  const snakeKeysParams = {
+    event_id: 1,
+    name: 'name',
+  }
+
+  describe('.camelKeysOf()', () => {
+    it('converts snake case to camel case', () => {
+      expect(ConvertCase.camelKeysOf(snakeKeysParams)).toEqual(camelKeysParams)
+    })
+  })
+
+  describe('.snakeKeysOf()', () => {
+    it('converts camel case to snake case', () => {
+      expect(ConvertCase.snakeKeysOf(camelKeysParams)).toEqual(snakeKeysParams)
+    })
+  })
+})


### PR DESCRIPTION
### Overview:概要
イベントへの参加登録機能を追加する。バックエンドとの接続仕様は [Issue で検討した内容](https://github.com/shinosakarb/tebukuro/issues/204#issuecomment-344825292)に基づく。

### Technical changes:技術的変更点
- イベント詳細ページに参加登録フォームのComponentを追加
- API に参加登録のインスタンス `participant` を追加
- 参加者を登録するアクション`JOIN_EVENT`を追加し、Event Reducer で処理
- 変数名について、javascript （キャメルケース）と Ruby （スネークケース）の差異を吸収するため、API で旧tebukuro で実装していた `ConvertCase.js` を流用
- `ConvertCase.js` が利用する `lodash` パッケージを追加

### Impact point:変更に関する影響箇所
イベント詳細ページから参加者が登録できるようになる。
ただし、認証はせず名前を入力するのみである。

### Change of UserInterface:UIの変更
後ほど追加予定

### Todos
- [x] 参加登録フォーム `ParticipantFormComponent` の作成、およびイベント`show`ページヘの追加
- [x] 中間レビュー
- [x] ConvertCaseの追加、および API の追加
- [x] 中間レビュー
- [x] Action および Reducer の追加
- [x] ImmutableJS の導入
- [x] 中間レビュー
- [x] ページヘの Action の追加
- [ ] 最終レビュー