### PR TITLE
Fix API endpoint error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
-    ["transform-define", "./env-config.js"]
+    ["transform-define", "./env-config.js"],
+    "transform-flow-strip-types"
   ],
   "env": {
     "development": {
@@ -15,8 +16,5 @@
         "next/babel"
       ]
     }
-  },
-  "plugins": [
-    "transform-flow-strip-types"
-  ]
+  }
 }

--- a/api/Base.js
+++ b/api/Base.js
@@ -20,27 +20,27 @@ export default class Base {
     return Promise.reject(new ApiResponseError(error))
   }
 
-  all() {
+  all = () => {
     const url = this.endpoints.all
     return this.client.get(url).then(this.onSuccess, this.onFailure)
   }
 
-  find(params: number) {
+  find = (params: number) => {
     const url = pathToRegexp.compile(this.endpoints.find)(params)
     return this.client.get(url).then(this.onSuccess, this.onFailure)
   }
 
-  create(params: Object) {
+  create = (params: Object) => {
     const url = pathToRegexp.compile(this.endpoints.create)(params)
     return this.client.post(url, params).then(this.onSuccess, this.onFailure)
   }
 
-  update(params: Object) {
+  update = (params: Object) => {
     const url = pathToRegexp.compile(this.endpoints.update)(params)
     return this.client.post(url, params).then(this.onSuccess, this.onFailure)
   }
 
-  delete(params: number) {
+  delete = (params: number) => {
     const url = pathToRegexp.compile(this.endpoints.delete)(params)
     return this.client.delete(url).then(this.onSuccess, this.onFailure)
   }

--- a/api/__test__/Base.spec.js
+++ b/api/__test__/Base.spec.js
@@ -3,10 +3,12 @@ import client from '../client'
 import Base from '../Base'
 import * as endpoints from '../../constants/endpoints'
 import eventParams from '../../factories/Event'
+import '../../env-config'
 
 const base = new Base(endpoints.event)
 
-const baseUrl = endpoints.event.all
+// Removing extra '/' from endpoint
+const baseUrl = process.env.BASE_URL + endpoints.event.all.substring(1)
 const detailUrl = `${baseUrl}/1`
 
 const events = [eventParams.event1, eventParams.event2]


### PR DESCRIPTION
### Overview:概要
後述の２点の不具合により、現状ではAPI のエンドポイントが作成されず、通信時にエラーが発生する。
本PRでは２点の不具合を修正する。

### Technical changes:技術的変更点
現状では下記２点の現象により、通信時にエラーが発生する。
- グローバル変数process.env.BASE_URLが定義されていない
- API インスタンスのメソッド内で`this` が`undefined` 

以下、原因および対策：
#### グローバル変数`process.env.BASE_URL`が定義されていない
- 原因： .babelrc での `plugin` フィールドの上書き
Reducer作成のPR（#25）で API作成のPR（#13 ）を取り込んだ際に、グローバル変数を設定するplugin フィールドが２重に記述された。これにより、前段で記述したAPIに必要な設定が上書きされ、適用されなくなった。

- 対策：.babelrc で単一の `plugin` フィールドに設定を記述する

#### API インスタンスのメソッド内で`this` が`undefined` 
- 原因： メソッドを関数として記述、もしくは constructorメソッドで `this` を `bind()` しなかった
API の Base クラスでは、メソッド内で`this`を使用するが、上記の対応が必要であるが、どちらも行わなかった。また、テストでは上記の対応が無くとも`this`が適切に設定されているため、発見できなかった（これについては、理由が良く分かっていません。。）

- 対策：[コーディング規約](https://github.com/shinosakarb/tebukuro/wiki/Coding-standards#javascript)に則り、メソッドを関数として記述する

現状のテストでは Babel の動作確認は行わないため、上記２点の原因についてテストで発見できず、ローカル環境およびnetlify上での動作確認で発見することとなった。
また、APIのテストでモックするURLに `process.env.BASE_URL` を含むように修正する。

### Impact point:変更に関する影響箇所
APIインスタンスでエンドポイントが正しく作成され、バックエンドへの接続を行うようになる。
動作確認は、ローカル環境および本PR でデプロイされた netlify のページで、想定するバックエンドのURLにアクセスしようとすることで確認した。

### Change of UserInterface:UIの変更
UIについての変更はなし
