### PR TITLE
Set DNS address for API in production

### DIFF
--- a/env-config.js
+++ b/env-config.js
@@ -1,5 +1,5 @@
 const prod = process.env.NODE_ENV === 'production'
 
 module.exports = {
-  'process.env.BASE_URL': prod ? 'https://api.example.com/' : 'http://localhost:3000/',
+  'process.env.BASE_URL': prod ? 'http://tebukuro-api.shinosakarb.org/' : 'http://localhost:3000/',
 }


### PR DESCRIPTION
### Overview:概要
本番で接続する API のベースURLを [Issue](https://github.com/shinosakarb/tebukuro/issues/217)に基づいて設定する。

### Technical changes:技術的変更点
環境変数で本番用のベースURL を `http://tebukuro-api.shinosakarb.org/` に設定する。
- 現時点ではSSL化していないため、http接続する
- 最終的な URL に変更があった場合は適宜対応

### Impact point:変更に関する影響箇所
本番モードでAPI への通信時の接続先が、GKE用に DNS へ登録した URL となる。
これにより、GKE への接続が可能となる。

### Change of UserInterface:UIの変更
UIの変更はなし
