### PR TITLE
Show the list of participants for the event

### DIFF
--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -2,15 +2,20 @@ import configureStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import promiseMiddleware from 'redux-promise'
 import Router from 'next/router'
+import { normalize } from 'normalizr'
+
 import * as Actions from '../event'
 import ActionsType from '../../constants/Actions'
 
-jest.mock('../../api/index')
-/* eslint-disable import/first */
-import mockAPI from '../../api/index'
-/* eslint-enable */
+import EventParams from '../../factories/Event'
+import ParticipantParams from '../../factories/Participant'
 
-const testParam = { id: 1 }
+import EventSchema from '../../schemas/event'
+import ParticipantSchema from '../../schemas/participant'
+
+jest.mock('../../api/index')
+// eslint-disable-next-line import/first
+import mockAPI from '../../api/index'
 
 const middlewares = [promiseMiddleware, thunk]
 const mockStore = configureStore(middlewares)
@@ -35,7 +40,7 @@ class MockedRouter {
 
 describe('EventAction', () => {
   beforeEach(() => {
-    store = mockStore({ event: testParam })
+    store = mockStore({ event: { id: 1 } })
   })
 
   describe('createEvent', () => {
@@ -43,11 +48,13 @@ describe('EventAction', () => {
       Router.router = new MockedRouter(newEventPath)
     })
 
+    const testParam = { ...EventParams.event1, participants: [] }
+    const result = normalize(testParam, EventSchema)
+
     describe('when successes to create the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
-        /* eslint-enable */
       })
       it('returns create action with event data.', () => {
         expect.assertions(2)
@@ -55,7 +62,7 @@ describe('EventAction', () => {
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.createEvent)
-            expect(action.payload).toEqual(testParam)
+            expect(action.payload).toEqual(result)
           })
       })
 
@@ -71,9 +78,8 @@ describe('EventAction', () => {
 
     describe('when fails to create the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(false)
-        /* eslint-enable */
       })
       it('returns create action with instance of Error.', () => {
         expect.assertions(2)
@@ -97,11 +103,16 @@ describe('EventAction', () => {
   })
 
   describe('fetchEvent', () => {
+    const testParam = {
+      ...EventParams.event1,
+      participants: Object.values(ParticipantParams),
+    }
+    const result = normalize(testParam, EventSchema)
+
     describe('when successes to fetch the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
-        /* eslint-enable */
       })
       it('returns fetch action with event data.', () => {
         expect.assertions(2)
@@ -109,16 +120,15 @@ describe('EventAction', () => {
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.fetchEvent)
-            expect(action.payload).toEqual(testParam)
+            expect(action.payload).toEqual(result)
           })
       })
     })
 
     describe('when fails to fetch the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(false)
-        /* eslint-enable */
       })
       it('returns fetch action with instance of Error.', () => {
         expect.assertions(2)
@@ -133,11 +143,13 @@ describe('EventAction', () => {
   })
 
   describe('registerForEvent', () => {
+    const testParam = ParticipantParams.participant1
+    const result = normalize(testParam, ParticipantSchema)
+
     describe('when successes to join the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
-        /* eslint-enable */
       })
       it('returns join action with participant data.', () => {
         expect.assertions(2)
@@ -145,16 +157,15 @@ describe('EventAction', () => {
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.registerForEvent)
-            expect(action.payload).toEqual(testParam)
+            expect(action.payload).toEqual(result)
           })
       })
     })
 
     describe('when fails to join the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(false)
-        /* eslint-enable */
       })
       it('returns join action with instance of Error.', () => {
         expect.assertions(2)

--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -2,20 +2,15 @@ import configureStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import promiseMiddleware from 'redux-promise'
 import Router from 'next/router'
-import { normalize } from 'normalizr'
-
 import * as Actions from '../event'
 import ActionsType from '../../constants/Actions'
 
-import EventParams from '../../factories/Event'
-import ParticipantParams from '../../factories/Participant'
-
-import EventSchema from '../../schemas/event'
-import ParticipantSchema from '../../schemas/participant'
-
 jest.mock('../../api/index')
-// eslint-disable-next-line import/first
+/* eslint-disable import/first */
 import mockAPI from '../../api/index'
+/* eslint-enable */
+
+const testParam = { id: 1 }
 
 const middlewares = [promiseMiddleware, thunk]
 const mockStore = configureStore(middlewares)
@@ -40,7 +35,7 @@ class MockedRouter {
 
 describe('EventAction', () => {
   beforeEach(() => {
-    store = mockStore({ event: { id: 1 } })
+    store = mockStore({ event: testParam })
   })
 
   describe('createEvent', () => {
@@ -48,13 +43,11 @@ describe('EventAction', () => {
       Router.router = new MockedRouter(newEventPath)
     })
 
-    const testParam = { ...EventParams.event1, participants: [] }
-    const result = normalize(testParam, EventSchema)
-
     describe('when successes to create the Event', () => {
       beforeEach(() => {
-        // eslint-disable-next-line no-underscore-dangle
+        /* eslint-disable no-underscore-dangle */
         mockAPI.__setMockResult(true)
+        /* eslint-enable */
       })
       it('returns create action with event data.', () => {
         expect.assertions(2)
@@ -62,7 +55,7 @@ describe('EventAction', () => {
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.createEvent)
-            expect(action.payload).toEqual(result)
+            expect(action.payload).toEqual(testParam)
           })
       })
 
@@ -78,8 +71,9 @@ describe('EventAction', () => {
 
     describe('when fails to create the Event', () => {
       beforeEach(() => {
-        // eslint-disable-next-line no-underscore-dangle
+        /* eslint-disable no-underscore-dangle */
         mockAPI.__setMockResult(false)
+        /* eslint-enable */
       })
       it('returns create action with instance of Error.', () => {
         expect.assertions(2)
@@ -103,16 +97,11 @@ describe('EventAction', () => {
   })
 
   describe('fetchEvent', () => {
-    const testParam = {
-      ...EventParams.event1,
-      participants: Object.values(ParticipantParams),
-    }
-    const result = normalize(testParam, EventSchema)
-
     describe('when successes to fetch the Event', () => {
       beforeEach(() => {
-        // eslint-disable-next-line no-underscore-dangle
+        /* eslint-disable no-underscore-dangle */
         mockAPI.__setMockResult(true)
+        /* eslint-enable */
       })
       it('returns fetch action with event data.', () => {
         expect.assertions(2)
@@ -120,15 +109,16 @@ describe('EventAction', () => {
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.fetchEvent)
-            expect(action.payload).toEqual(result)
+            expect(action.payload).toEqual(testParam)
           })
       })
     })
 
     describe('when fails to fetch the Event', () => {
       beforeEach(() => {
-        // eslint-disable-next-line no-underscore-dangle
+        /* eslint-disable no-underscore-dangle */
         mockAPI.__setMockResult(false)
+        /* eslint-enable */
       })
       it('returns fetch action with instance of Error.', () => {
         expect.assertions(2)
@@ -143,13 +133,11 @@ describe('EventAction', () => {
   })
 
   describe('registerForEvent', () => {
-    const testParam = ParticipantParams.participant1
-    const result = normalize(testParam, ParticipantSchema)
-
     describe('when successes to join the Event', () => {
       beforeEach(() => {
-        // eslint-disable-next-line no-underscore-dangle
+        /* eslint-disable no-underscore-dangle */
         mockAPI.__setMockResult(true)
+        /* eslint-enable */
       })
       it('returns join action with participant data.', () => {
         expect.assertions(2)
@@ -157,15 +145,16 @@ describe('EventAction', () => {
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.registerForEvent)
-            expect(action.payload).toEqual(result)
+            expect(action.payload).toEqual(testParam)
           })
       })
     })
 
     describe('when fails to join the Event', () => {
       beforeEach(() => {
-        // eslint-disable-next-line no-underscore-dangle
+        /* eslint-disable no-underscore-dangle */
         mockAPI.__setMockResult(false)
+        /* eslint-enable */
       })
       it('returns join action with instance of Error.', () => {
         expect.assertions(2)

--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -2,6 +2,7 @@ import configureStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import promiseMiddleware from 'redux-promise'
 import Router from 'next/router'
+import { Map } from 'immutable'
 import * as Actions from '../event'
 import ActionsType from '../../constants/Actions'
 
@@ -10,7 +11,7 @@ jest.mock('../../api/index')
 import mockAPI from '../../api/index'
 /* eslint-enable */
 
-const testParam = { id: 1 }
+const testParam = new Map({ entityId: 1 })
 
 const middlewares = [promiseMiddleware, thunk]
 const mockStore = configureStore(middlewares)

--- a/actions/event.js
+++ b/actions/event.js
@@ -2,19 +2,43 @@
 import { createAction } from 'redux-actions'
 import Router from 'next/router'
 import type { Dispatch } from 'redux'
+import { normalize } from 'normalizr'
 import ActionsType from '../constants/Actions'
 import { event, participant } from '../api'
 import type { EventProps } from '../types/Event'
+import EventSchema from '../schemas/event'
+import ParticipantSchema from '../schemas/participant'
 
-const create = createAction(ActionsType.Event.createEvent, event.create)
+const create = createAction(ActionsType.Event.createEvent)
+const fetch = createAction(ActionsType.Event.fetchEvent)
+const join = createAction(ActionsType.Event.registerForEvent)
 
 // TODO: Return reject in thunk.
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => (
-  dispatch(create(params)).then((res) => {
-    const { id } = getState().event
-    !res.error && Router.replace(`/event/show?id=${id}`, `/event/${id}`)
-  })
+  event.create(params)
+    .then((res) => {
+      const normalizedValue = normalize(res, EventSchema)
+      return dispatch(create(normalizedValue))
+    })
+    .then(() => {
+      const { id } = getState().event
+      Router.replace(`/event/show?id=${id}`, `/event/${id}`)
+    })
+    .catch(error => dispatch(create(error)))
 )
 
-export const fetchEvent = createAction(ActionsType.Event.fetchEvent, event.find)
-export const registerForEvent = createAction(ActionsType.Event.registerForEvent, participant.create)
+export const fetchEvent = (id: number) => (dispatch: Dispatch) =>
+  event.find(id)
+    .then((res) => {
+      const normalizedValue = normalize(res, EventSchema)
+      return dispatch(fetch(normalizedValue))
+    })
+    .catch(error => dispatch(fetch(error)))
+
+export const registerForEvent = (params: Object) => (dispatch: Dispatch) =>
+  participant.create(params)
+    .then((res) => {
+      const normalizedValue = normalize(res, ParticipantSchema)
+      return dispatch(join(normalizedValue))
+    })
+    .catch(error => dispatch(join(error)))

--- a/actions/event.js
+++ b/actions/event.js
@@ -2,43 +2,19 @@
 import { createAction } from 'redux-actions'
 import Router from 'next/router'
 import type { Dispatch } from 'redux'
-import { normalize } from 'normalizr'
 import ActionsType from '../constants/Actions'
 import { event, participant } from '../api'
 import type { EventProps } from '../types/Event'
-import EventSchema from '../schemas/event'
-import ParticipantSchema from '../schemas/participant'
 
-const create = createAction(ActionsType.Event.createEvent)
-const fetch = createAction(ActionsType.Event.fetchEvent)
-const join = createAction(ActionsType.Event.registerForEvent)
+const create = createAction(ActionsType.Event.createEvent, event.create)
 
 // TODO: Return reject in thunk.
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => (
-  event.create(params)
-    .then((res) => {
-      const normalizedValue = normalize(res, EventSchema)
-      return dispatch(create(normalizedValue))
-    })
-    .then(() => {
-      const { id } = getState().event
-      Router.replace(`/event/show?id=${id}`, `/event/${id}`)
-    })
-    .catch(error => dispatch(create(error)))
+  dispatch(create(params)).then((res) => {
+    const { id } = getState().event
+    !res.error && Router.replace(`/event/show?id=${id}`, `/event/${id}`)
+  })
 )
 
-export const fetchEvent = (id: number) => (dispatch: Dispatch) =>
-  event.find(id)
-    .then((res) => {
-      const normalizedValue = normalize(res, EventSchema)
-      return dispatch(fetch(normalizedValue))
-    })
-    .catch(error => dispatch(fetch(error)))
-
-export const registerForEvent = (params: Object) => (dispatch: Dispatch) =>
-  participant.create(params)
-    .then((res) => {
-      const normalizedValue = normalize(res, ParticipantSchema)
-      return dispatch(join(normalizedValue))
-    })
-    .catch(error => dispatch(join(error)))
+export const fetchEvent = createAction(ActionsType.Event.fetchEvent, event.find)
+export const registerForEvent = createAction(ActionsType.Event.registerForEvent, participant.create)

--- a/actions/event.js
+++ b/actions/event.js
@@ -4,6 +4,7 @@ import Router from 'next/router'
 import type { Dispatch } from 'redux'
 import ActionsType from '../constants/Actions'
 import { event, participant } from '../api'
+import { getEventId } from '../selectors/event'
 import type { EventProps } from '../types/Event'
 
 const create = createAction(ActionsType.Event.createEvent, event.create)
@@ -11,7 +12,7 @@ const create = createAction(ActionsType.Event.createEvent, event.create)
 // TODO: Return reject in thunk.
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => (
   dispatch(create(params)).then((res) => {
-    const id = getState().event.get('entityId')
+    const id = getEventId(getState())
     !res.error && Router.replace(`/event/show?id=${id}`, `/event/${id}`)
   })
 )

--- a/actions/event.js
+++ b/actions/event.js
@@ -11,7 +11,7 @@ const create = createAction(ActionsType.Event.createEvent, event.create)
 // TODO: Return reject in thunk.
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => (
   dispatch(create(params)).then((res) => {
-    const { id } = getState().event
+    const id = getState().event.get('entityId')
     !res.error && Router.replace(`/event/show?id=${id}`, `/event/${id}`)
   })
 )

--- a/components/ParticipantForm/__tests__/ParticipantForm.spec.js
+++ b/components/ParticipantForm/__tests__/ParticipantForm.spec.js
@@ -11,10 +11,21 @@ const testProps = {
   eventId: 1,
 }
 
+const errorProps = {
+  ...testProps,
+  errors: ['名前を入力して下さい'],
+}
 
 describe('ParticipantForm', () => {
   it('renders participant form component', () => {
     const wrapper = shallow(<ParticipantForm {...testProps} onSubmit={jest.fn()} />)
+    const tree = shallowToJson(wrapper)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders participant form component with error message', () => {
+    const wrapper = shallow(<ParticipantForm {...errorProps} onSubmit={jest.fn()} />)
     const tree = shallowToJson(wrapper)
 
     expect(tree).toMatchSnapshot()

--- a/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
@@ -29,3 +29,38 @@ exports[`ParticipantForm renders participant form component 1`] = `
   </form>
 </div>
 `;
+
+exports[`ParticipantForm renders participant form component with error message 1`] = `
+<div>
+  <h3>
+    Event participation form
+  </h3>
+  <ul>
+    <li>
+      名前を入力して下さい
+    </li>
+  </ul>
+  <form
+    onSubmit={[Function]}
+  >
+    <div>
+      <label
+        htmlFor="name"
+      >
+        name
+        <input
+          id="name"
+          onChange={[Function]}
+          type="text"
+          value=""
+        />
+      </label>
+    </div>
+    <div>
+      <input
+        type="submit"
+      />
+    </div>
+  </form>
+</div>
+`;

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 type Props = {
   onSubmit: Function,
   eventId: ?number,
+  errors: ?string[],
 }
 type State = {
   name: string,
@@ -36,6 +37,12 @@ export default class ParticipantForm extends Component<Props, State> {
     return (
       <div>
         <h3>Event participation form</h3>
+        { this.props.errors &&
+          <ul>
+            { this.props.errors.map(error =>
+              <li>{ error }</li>)}
+          </ul>
+        }
         <form onSubmit={this.onSubmitHandler}>
           <div>
             <label htmlFor="name">

--- a/components/ParticipantsList/__tests__/ParticipantListComponent.spec.js
+++ b/components/ParticipantsList/__tests__/ParticipantListComponent.spec.js
@@ -1,0 +1,14 @@
+import { shallow } from 'enzyme'
+import shallowToJson from 'enzyme-to-json'
+import ParticipantList from '../index'
+import ParticipantParams from '../../../factories/Participant'
+
+describe('ParticipantList Component', () => {
+  it('renders self.', () => {
+    const participants = Object.values(ParticipantParams)
+    const component = shallow(<ParticipantList participants={participants} />)
+    const tree = shallowToJson(component)
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
+++ b/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ParticipantList Component renders self. 1`] = `
+<div>
+  <ul>
+    <li
+      key="1"
+    >
+      participant1
+    </li>
+    <li
+      key="2"
+    >
+      participant2
+    </li>
+  </ul>
+</div>
+`;

--- a/components/ParticipantsList/index.js
+++ b/components/ParticipantsList/index.js
@@ -1,0 +1,15 @@
+// @flow
+import React from 'react'
+
+const ParticipantList = (props: {participants: ?Object[]}) => (
+  <div>
+    { props.participants &&
+      <ul>
+        { props.participants.map(participant =>
+          <li key={participant.id}>{ participant.name }</li>)}
+      </ul>
+    }
+  </div>
+)
+
+export default ParticipantList

--- a/factories/Event.js
+++ b/factories/Event.js
@@ -3,6 +3,7 @@ export default {
     id: 1,
     name: 'event1',
     description: 'This is the first event.',
+    participants: [],
   },
   errorEvent: {
     errors: ['nameを入力してください', 'nameは１０文字以内です'],

--- a/factories/Participant.js
+++ b/factories/Participant.js
@@ -4,7 +4,9 @@ export default {
     eventId: 1,
     name: 'participant1',
   },
-  errorParticipant: {
-    errors: ['nameを入力してください', 'nameは１０文字以内です'],
+  participant2: {
+    id: 2,
+    eventId: 1,
+    name: 'participant2',
   },
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-promise": "^0.5.3",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "reselect": "^3.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.4",
     "next": "^4.0.0",
     "next-redux-wrapper": "^1.3.4",
+    "normalizr": "^3.2.4",
     "path-to-regexp": "^2.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -30,14 +30,6 @@ exports[`ShowEvent renders the page not found error page. 1`] = `
 
 exports[`ShowEvent renders the page with error messages. 1`] = `
 <div>
-  <ul>
-    <li>
-      nameを入力してください
-    </li>
-    <li>
-      nameは１０文字以内です
-    </li>
-  </ul>
   <h3>
     This is the event page!
   </h3>

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -19,6 +19,22 @@ exports[`ShowEvent renders the event page. 1`] = `
     eventId={1}
     onSubmit={[Function]}
   />
+  <ParticipantList
+    participants={
+      Array [
+        Object {
+          "eventId": 1,
+          "id": 1,
+          "name": "participant1",
+        },
+        Object {
+          "eventId": 1,
+          "id": 2,
+          "name": "participant2",
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -45,6 +61,22 @@ exports[`ShowEvent renders the page with error messages. 1`] = `
   />
   <ParticipantForm
     onSubmit={[Function]}
+  />
+  <ParticipantList
+    participants={
+      Array [
+        Object {
+          "eventId": 1,
+          "id": 1,
+          "name": "participant1",
+        },
+        Object {
+          "eventId": 1,
+          "id": 2,
+          "name": "participant2",
+        },
+      ]
+    }
   />
 </div>
 `;

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -11,6 +11,7 @@ exports[`ShowEvent renders the event page. 1`] = `
         "description": "This is the first event.",
         "id": 1,
         "name": "event1",
+        "participants": Array [],
       }
     }
   />

--- a/pageTests/event/show.spec.js
+++ b/pageTests/event/show.spec.js
@@ -1,7 +1,8 @@
 import { shallow, mount } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
 import { ShowEvent } from '../../pages/event/show'
-import Params from '../../factories/Event'
+import EventParams from '../../factories/Event'
+import ParticipantParams from '../../factories/Participant'
 
 jest.mock('../../components/Event', () => 'EventComponent')
 jest.mock('../../actions/event', () => ({
@@ -9,8 +10,9 @@ jest.mock('../../actions/event', () => ({
 }))
 
 const testProps = {
-  url: { query: { id: Params.event1.id } },
-  event: Params.event1,
+  url: { query: { id: EventParams.event1.id } },
+  event: EventParams.event1,
+  participants: Object.values(ParticipantParams),
   fetchEvent: jest.fn(),
   registerForEvent: jest.fn(),
 }
@@ -28,7 +30,7 @@ describe('ShowEvent', () => {
   })
 
   it('renders the page with error messages.', () => {
-    const errorTestProps = { ...testProps, event: Params.errorEvent }
+    const errorTestProps = { ...testProps, event: EventParams.errorEvent }
     const page = shallow(<ShowEvent {...errorTestProps} />)
     const tree = shallowToJson(page)
 
@@ -47,6 +49,6 @@ describe('ShowEvent', () => {
     mount(<ShowEvent {...testProps} />)
 
     expect(testProps.fetchEvent).toHaveBeenCalledTimes(1)
-    expect(testProps.fetchEvent).toBeCalledWith({ id: Params.event1.id })
+    expect(testProps.fetchEvent).toBeCalledWith({ id: EventParams.event1.id })
   })
 })

--- a/pages/event/new.js
+++ b/pages/event/new.js
@@ -3,6 +3,7 @@ import React from 'react'
 import withRedux from 'next-redux-wrapper'
 import createStore from '../../store'
 import { createEvent } from '../../actions/event'
+import { getEventErrorsArray } from '../../selectors/event'
 import EventFormComponent from '../../components/EventForm'
 
 type EventFormProps = {
@@ -25,7 +26,7 @@ export const NewEvent = (props: EventFormProps) => (
 
 const mapDispatchToProps = { createEvent }
 const mapStateToProps = state => (
-  { errors: state.event.get('errors').toArray() }
+  { errors: getEventErrorsArray(state) }
 )
 
 const connectProps = {

--- a/pages/event/new.js
+++ b/pages/event/new.js
@@ -25,7 +25,7 @@ export const NewEvent = (props: EventFormProps) => (
 
 const mapDispatchToProps = { createEvent }
 const mapStateToProps = state => (
-  { errors: state.event.errors }
+  { errors: state.event.get('errors').toArray() }
 )
 
 const connectProps = {

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -4,9 +4,11 @@ import withRedux from 'next-redux-wrapper'
 import Error from 'next/error'
 import createStore from '../../store'
 import { fetchEvent, registerForEvent } from '../../actions/event'
-import type { EventId, EventProps } from '../../types/Event'
+import { getCurrentEvent } from '../../selectors/event'
+import { getParticipantErrorsArray } from '../../selectors/participant'
 import EventComponent from '../../components/Event'
 import ParticipantFormComponent from '../../components/ParticipantForm'
+import type { EventId, EventProps } from '../../types/Event'
 
 type Props = {
   url: { query: EventId },
@@ -47,13 +49,10 @@ export class ShowEvent extends Component<Props> {
   }
 }
 
-const mapStateToProps = (state) => {
-  const id = state.event.get('entityId').toString()
-  return {
-    event: state.event.getIn(['entities', id]).toObject(),
-    participantErrors: state.participant.get('errors').toArray(),
-  }
-}
+const mapStateToProps = state => ({
+  event: getCurrentEvent(state),
+  participantErrors: getParticipantErrorsArray(state),
+})
 
 const mapDispatchToProps = { fetchEvent, registerForEvent }
 

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -5,14 +5,16 @@ import Error from 'next/error'
 import createStore from '../../store'
 import { fetchEvent, registerForEvent } from '../../actions/event'
 import { getCurrentEvent } from '../../selectors/event'
-import { getParticipantErrorsArray } from '../../selectors/participant'
+import { getParticipants, getParticipantErrorsArray } from '../../selectors/participant'
 import EventComponent from '../../components/Event'
 import ParticipantFormComponent from '../../components/ParticipantForm'
+import ParticipantsListComponent from '../../components/ParticipantsList'
 import type { EventId, EventProps } from '../../types/Event'
 
 type Props = {
   url: { query: EventId },
   event: EventProps,
+  participants: ?Object[],
   participantErrors: ?string[],
   fetchEvent: Function,
   registerForEvent: Function,
@@ -44,6 +46,7 @@ export class ShowEvent extends Component<Props> {
           eventId={event.id}
           errors={this.props.participantErrors}
         />
+        <ParticipantsListComponent participants={this.props.participants} />
       </div>
     )
   }
@@ -51,6 +54,7 @@ export class ShowEvent extends Component<Props> {
 
 const mapStateToProps = state => ({
   event: getCurrentEvent(state),
+  participants: getParticipants(state),
   participantErrors: getParticipantErrorsArray(state),
 })
 

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -11,6 +11,7 @@ import ParticipantFormComponent from '../../components/ParticipantForm'
 type Props = {
   url: { query: EventId },
   event: EventProps,
+  participantErrors: ?string[],
   fetchEvent: Function,
   registerForEvent: Function,
 }
@@ -27,31 +28,32 @@ export class ShowEvent extends Component<Props> {
 
   render() {
     const { event } = this.props
+
     if (this.isNotFoundError(event.errors)) {
       return <Error statusCode="404" />
     }
 
     return (
       <div>
-        { event.errors &&
-          <ul>
-            { event.errors.map(error => <li>{ error }</li>) }
-          </ul>
-        }
         <h3>This is the event page!</h3>
         <EventComponent event={event} />
         <ParticipantFormComponent
           onSubmit={this.props.registerForEvent}
-          eventId={this.props.event.id}
+          eventId={event.id}
+          errors={this.props.participantErrors}
         />
       </div>
     )
   }
 }
 
-const mapStateToProps = state => ({
-  event: state.event,
-})
+const mapStateToProps = (state) => {
+  const id = state.event.get('entityId').toString()
+  return {
+    event: state.event.getIn(['entities', id]).toObject(),
+    participantErrors: state.participant.get('errors').toArray(),
+  }
+}
 
 const mapDispatchToProps = { fetchEvent, registerForEvent }
 

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -1,28 +1,32 @@
 import { createAction } from 'redux-actions'
-import { Set } from 'immutable'
+import { List } from 'immutable'
 
 import EventReducer, { eventInitialState } from '../event'
 import Actions from '../../constants/Actions'
 import ApiResponseError from '../../api/ApiResponseError'
-import ConvertCase from '../../utils/ConvertCase'
-
-import EventModel from '../../models/Event'
-import ParticipantModel from '../../models/Participant'
-
 import EventParams from '../../factories/Event'
 import ParticipantParams from '../../factories/Participant'
 
+const initialState = eventInitialState
+const testEventParams = EventParams.event1
+const testParticipantParams = ParticipantParams.participant1
+
+const testEventResult = initialState.merge({
+  entityId: testEventParams.id,
+  entities: { [testEventParams.id]: testEventParams },
+  errors: [],
+})
 
 const error = {
   response: { data: { name: ['を入力して下さい', 'は１０文字以下です'] } },
 }
 
-const errorMessages = ['nameを入力して下さい', 'nameは１０文字以下です']
+const errorMessages = new List(['nameを入力して下さい', 'nameは１０文字以下です'])
 
 describe('Event Reducer', () => {
   describe('when initial state', () => {
     it('should return the initial state', () => {
-      expect(EventReducer(undefined, {})).toEqual(eventInitialState)
+      expect(EventReducer(undefined, {})).toEqual(initialState)
     })
   })
 
@@ -31,15 +35,15 @@ describe('Event Reducer', () => {
 
     describe('with success event create', () => {
       it('should return created event', () => {
-        const eventState = EventReducer(null, createEvent(EventParams.event1))
-        expect(eventState).toEqual(new EventModel(EventParams.event1))
+        const subject = EventReducer(initialState, createEvent(testEventParams))
+        expect(subject).toEqual(testEventResult)
       })
     })
 
     describe('with failure event create', () => {
       it('should return error message', () => {
-        const eventState = EventReducer(null, createEvent(new ApiResponseError(error)))
-        expect(eventState.errors).toEqual(errorMessages)
+        const subject = EventReducer(initialState, createEvent(new ApiResponseError(error)))
+        expect(subject.get('errors')).toEqual(errorMessages)
       })
     })
   })
@@ -49,45 +53,40 @@ describe('Event Reducer', () => {
 
     describe('with success event fetch', () => {
       it('should return fetched event', () => {
-        const eventState = EventReducer(null, fetchEvent(EventParams.event1))
-        expect(eventState).toEqual(new EventModel(EventParams.event1))
+        const subject = EventReducer(initialState, fetchEvent(testEventParams))
+        expect(subject).toEqual(testEventResult)
       })
     })
 
     describe('with failure event fetch', () => {
       it('should return error message', () => {
-        const eventState = EventReducer(null, fetchEvent(new ApiResponseError(error)))
-        expect(eventState.errors).toEqual(errorMessages)
+        const subject = EventReducer(initialState, fetchEvent(new ApiResponseError(error)))
+        expect(subject.get('errors')).toEqual(errorMessages)
       })
     })
   })
 
-  describe('when JOIN_EVENT action', () => {
+  describe('when REGISTER_FOR_EVENT action', () => {
     const registerForEvent = createAction(Actions.Event.registerForEvent)
 
-    const participant = ParticipantParams.participant1
-    const receivedData = ConvertCase.snakeKeysOf(participant)
+    const prevState = testEventResult
+    const eventId = prevState.get('entityId').toString()
+    const nextState = prevState.updateIn(
+      ['entities', eventId, 'participants'],
+      participants => participants.push(testParticipantParams.id),
+    )
 
-    const prevState = new EventModel({
-      ...EventParams.event1,
-      errors: ['Error'],
-    })
-    const nextState = new EventModel({
-      ...EventParams.event1,
-      participants: Set.of(new ParticipantModel(participant)),
-    })
-
-    describe('with success event join', () => {
-      it('should return joined event', () => {
-        const eventState = EventReducer(prevState, registerForEvent(receivedData))
-        expect(eventState).toEqual(nextState)
+    describe('with success event register', () => {
+      it('should add registered participant', () => {
+        const subject = EventReducer(prevState, registerForEvent(testParticipantParams))
+        expect(subject).toEqual(nextState)
       })
     })
 
-    describe('with failure event join', () => {
-      it('should return error message', () => {
-        const eventState = EventReducer(prevState, registerForEvent(new ApiResponseError(error)))
-        expect(eventState).toEqual(prevState.set('errors', errorMessages))
+    describe('with failure event registerFor', () => {
+      it('should keep previous state', () => {
+        const subject = EventReducer(prevState, registerForEvent(new ApiResponseError(error)))
+        expect(subject).toEqual(prevState)
       })
     })
   })

--- a/reducers/__tests__/ParticipantReducer.spec.js
+++ b/reducers/__tests__/ParticipantReducer.spec.js
@@ -1,0 +1,74 @@
+import { createAction } from 'redux-actions'
+import { List } from 'immutable'
+
+import ParticipantReducer, { participantInitialState } from '../participant'
+import Actions from '../../constants/Actions'
+import ApiResponseError from '../../api/ApiResponseError'
+import EventParams from '../../factories/Event'
+import ParticipantParams from '../../factories/Participant'
+import ConvertCase from '../../utils/ConvertCase'
+
+const initialState = participantInitialState
+const participantParams1 = ParticipantParams.participant1
+const participantParams2 = ParticipantParams.participant2
+const participantEntity1 = { [participantParams1.id]: participantParams1 }
+const participantEntity2 = { [participantParams2.id]: participantParams2 }
+
+const error = {
+  response: { data: { name: ['を入力して下さい', 'は１０文字以下です'] } },
+}
+const errorMessages = new List(['nameを入力して下さい', 'nameは１０文字以下です'])
+
+describe('Participant Reducer', () => {
+  describe('when initial state', () => {
+    it('should return the initial state', () => {
+      expect(ParticipantReducer(undefined, {})).toEqual(initialState)
+    })
+  })
+
+  describe('when FETCH_EVENT action', () => {
+    const fetchEvent = createAction(Actions.Event.fetchEvent)
+    const eventParams = {
+      ...EventParams.event1,
+      participants: [ConvertCase.snakeKeysOf(participantParams1)],
+    }
+
+    describe('with success event fetch', () => {
+      it('should return participants in fetched event', () => {
+        const subject = ParticipantReducer(initialState, fetchEvent(eventParams))
+        expect(subject).toEqual(initialState.merge({ entities: participantEntity1 }))
+      })
+    })
+
+    describe('with failure event fetch', () => {
+      it('should keep state', () => {
+        const subject =
+          ParticipantReducer(initialState, fetchEvent(new ApiResponseError(error)))
+        expect(subject).toEqual(initialState)
+      })
+    })
+  })
+
+  describe('when REGISTER_FOR_EVENT action', () => {
+    const registerForEvent = createAction(Actions.Event.registerForEvent)
+
+    describe('with success event registerFor', () => {
+      it('should add regitered participant', () => {
+        const prevState = initialState.merge({ entities: participantEntity1 })
+        const subject = ParticipantReducer(
+          prevState,
+          registerForEvent(ConvertCase.snakeKeysOf(participantParams2)),
+        )
+        expect(subject).toEqual(prevState.mergeDeep({ entities: participantEntity2 }))
+      })
+    })
+
+    describe('with failure event register', () => {
+      it('should return error message', () => {
+        const subject =
+          ParticipantReducer(initialState, registerForEvent(new ApiResponseError(error)))
+        expect(subject.get('errors')).toEqual(errorMessages)
+      })
+    })
+  })
+})

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -12,6 +12,7 @@ export const eventInitialState = new Map({
   errors: new List(),
 })
 
+// TODO: Normalize in Reducer is **NOT** recommended. Need to be refactored.
 const setEvent = {
   next: (state, action) => {
     const normalizedPayload = normalize(action.payload, EventSchema)

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -1,39 +1,46 @@
 // @flow
 import { handleActions } from 'redux-actions'
-import Actions from '../constants/Actions'
-import EventModel from '../models/Event'
-import ParticipantModel from '../models/Participant'
-import ConvertCase from '../utils/ConvertCase'
+import { normalize } from 'normalizr'
+import { Map, List } from 'immutable'
 
-export const eventInitialState = new EventModel()
+import Actions from '../constants/Actions'
+import EventSchema from '../schemas/event'
+
+export const eventInitialState = new Map({
+  entityId: 0,
+  entities: new Map(),
+  errors: new List(),
+})
+
+const setEvent = {
+  next: (state, action) => {
+    const normalizedPayload = normalize(action.payload, EventSchema)
+
+    return state.merge({
+      entityId: normalizedPayload.result,
+      entities: normalizedPayload.entities.event,
+      errors: [],
+    })
+  },
+  throw: (state, action) => state.merge({ errors: action.payload.errors }),
+}
+
+const mergeParticipant = {
+  next: (state, action) => {
+    const eventId = state.get('entityId').toString()
+    const participantId = action.payload.id
+
+    return state.updateIn(
+      ['entities', eventId, 'participants'],
+      participants => participants.push(participantId),
+    )
+  },
+}
 
 const eventReducerMap = {
-  [Actions.Event.createEvent]: {
-    next: (state, action) => new EventModel(action.payload),
-    throw: (state, action) => (
-      new EventModel({ errors: action.payload.errors })
-    ),
-  },
-
-  [Actions.Event.fetchEvent]: {
-    next: (state, action) => new EventModel(action.payload),
-    throw: (state, action) => (
-      new EventModel({ errors: action.payload.errors })
-    ),
-  },
-
-  [Actions.Event.registerForEvent]: {
-    next: (state, action) => {
-      const participant = new ParticipantModel(ConvertCase.camelKeysOf(action.payload))
-      // Clear error message of previous error.
-      const event = state.set('errors', [])
-
-      return event.setParticipants([...state.get('participants'), participant])
-    },
-    throw: (state, action) => (
-      state.set('errors', action.payload.errors)
-    ),
-  },
+  [Actions.Event.createEvent]: setEvent,
+  [Actions.Event.fetchEvent]: setEvent,
+  [Actions.Event.registerForEvent]: mergeParticipant,
 }
 
 export default handleActions(eventReducerMap, eventInitialState)

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux'
 import event from './event'
+import participant from './participant'
 
 export default combineReducers({
   event,
+  participant,
 })

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -18,6 +18,7 @@ const toCamelCase = payload => (
   _.mapValues(payload, val => ConvertCase.camelKeysOf(val))
 )
 
+// TODO: Normalize in Reducer is **NOT** recommended. Need to be refactored.
 const participantReducerMap = {
   [Actions.Event.fetchEvent]: {
     next: (state, action) => {

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -1,0 +1,48 @@
+// @flow
+import { handleActions } from 'redux-actions'
+import { normalize } from 'normalizr'
+import { Map, List } from 'immutable'
+import _ from 'lodash'
+
+import Actions from '../constants/Actions'
+import EventSchema from '../schemas/event'
+import ParticipantSchema from '../schemas/participant'
+import ConvertCase from '../utils/ConvertCase'
+
+export const participantInitialState = new Map({
+  entities: new Map(),
+  errors: new List(),
+})
+
+const toCamelCase = payload => (
+  _.mapValues(payload, val => ConvertCase.camelKeysOf(val))
+)
+
+const participantReducerMap = {
+  [Actions.Event.fetchEvent]: {
+    next: (state, action) => {
+      const normalizedPayload = normalize(action.payload, EventSchema)
+      const participant = toCamelCase(normalizedPayload.entities.participant)
+
+      return state.merge({
+        entities: participant,
+        errors: [],
+      })
+    },
+  },
+
+  [Actions.Event.registerForEvent]: {
+    next: (state, action) => {
+      const normalizedPayload = normalize(action.payload, ParticipantSchema)
+      const participant = toCamelCase(normalizedPayload.entities.participant)
+
+      return state.mergeDeep({
+        entities: participant,
+        errors: [],
+      })
+    },
+    throw: (state, action) => state.merge({ errors: action.payload.errors }),
+  },
+}
+
+export default handleActions(participantReducerMap, participantInitialState)

--- a/schemas/event.js
+++ b/schemas/event.js
@@ -1,0 +1,8 @@
+import { schema } from 'normalizr'
+import ParticipantSchema from './participant'
+
+const EventSchema = new schema.Entity('event', {
+  participants: [ParticipantSchema],
+})
+
+export default EventSchema

--- a/schemas/participant.js
+++ b/schemas/participant.js
@@ -1,0 +1,5 @@
+import { schema } from 'normalizr'
+
+const ParticipantSchema = new schema.Entity('participant')
+
+export default ParticipantSchema

--- a/selectors/__tests__/EventSelector.spec.js
+++ b/selectors/__tests__/EventSelector.spec.js
@@ -1,0 +1,36 @@
+import { Map, List } from 'immutable'
+import * as EventSelector from '../event'
+import EventParams from '../../factories/Event'
+
+const eventId = EventParams.event1.id
+const errorMessages = ['nameを入力して下さい', 'nameは１０文字以下です']
+
+const testEventState = new Map({
+  entityId: eventId,
+  entities: new Map({ [eventId]: new Map(EventParams.event1) }),
+  errors: new List(errorMessages),
+})
+const mockState = { event: testEventState }
+
+describe('EventSelector', () => {
+  describe('getEventId', () => {
+    it('returns event id from state.', () => {
+      const subject = EventSelector.getEventId(mockState)
+      expect(subject).toEqual(eventId)
+    })
+  })
+
+  describe('getEventErrorsArray', () => {
+    it('returns an array of error messages.', () => {
+      const subject = EventSelector.getEventErrorsArray(mockState)
+      expect(subject).toEqual(errorMessages)
+    })
+  })
+
+  describe('getCurrentEvent', () => {
+    it('returns event object pointed by entityId.', () => {
+      const subject = EventSelector.getCurrentEvent(mockState)
+      expect(subject).toEqual(EventParams.event1)
+    })
+  })
+})

--- a/selectors/__tests__/ParticipantSelector.spec.js
+++ b/selectors/__tests__/ParticipantSelector.spec.js
@@ -1,14 +1,29 @@
 import { Map, List } from 'immutable'
 import * as ParticipantSelector from '../participant'
+import ParticipantParams from '../../factories/Participant'
 
 const errorMessages = ['nameを入力して下さい', 'nameは１０文字以下です']
 
+const { participant1, participant2 } = ParticipantParams
+
 const testParticipantState = new Map({
+  entities: new Map({
+    [participant1.id]: new Map(participant1),
+    [participant2.id]: new Map(participant2),
+  }),
+
   errors: new List(errorMessages),
 })
 const mockState = { participant: testParticipantState }
 
 describe('ParticipantSelector', () => {
+  describe('getParticipantsArray', () => {
+    it('returns an array of participants.', () => {
+      const subject = ParticipantSelector.getParticipants(mockState)
+      expect(subject).toEqual(Object.values(ParticipantParams))
+    })
+  })
+
   describe('getParticipantErrorsArray', () => {
     it('returns an array of error messages.', () => {
       const subject = ParticipantSelector.getParticipantErrorsArray(mockState)

--- a/selectors/__tests__/ParticipantSelector.spec.js
+++ b/selectors/__tests__/ParticipantSelector.spec.js
@@ -1,0 +1,18 @@
+import { Map, List } from 'immutable'
+import * as ParticipantSelector from '../participant'
+
+const errorMessages = ['nameを入力して下さい', 'nameは１０文字以下です']
+
+const testParticipantState = new Map({
+  errors: new List(errorMessages),
+})
+const mockState = { participant: testParticipantState }
+
+describe('ParticipantSelector', () => {
+  describe('getParticipantErrorsArray', () => {
+    it('returns an array of error messages.', () => {
+      const subject = ParticipantSelector.getParticipantErrorsArray(mockState)
+      expect(subject).toEqual(errorMessages)
+    })
+  })
+})

--- a/selectors/event.js
+++ b/selectors/event.js
@@ -1,0 +1,12 @@
+// @flow
+import { createSelector } from 'reselect'
+
+const getEventEntities = state => state.event.get('entities')
+const getEventErrors = state => state.event.get('errors')
+
+export const getEventId = (state: Object) => state.event.get('entityId')
+export const getEventErrorsArray = createSelector(getEventErrors, errors => errors.toArray())
+export const getCurrentEvent = createSelector(
+  [getEventId, getEventEntities],
+  (id, entities) => entities.get(id.toString()).toObject(),
+)

--- a/selectors/participant.js
+++ b/selectors/participant.js
@@ -1,0 +1,7 @@
+// @flow
+import { createSelector } from 'reselect'
+
+const participantErrors = state => state.participant.get('errors')
+// eslint-disable-next-line import/prefer-default-export
+export const getParticipantErrorsArray =
+  createSelector(participantErrors, errors => errors.toArray())

--- a/selectors/participant.js
+++ b/selectors/participant.js
@@ -1,7 +1,16 @@
 // @flow
 import { createSelector } from 'reselect'
 
+const participantEntities = state => state.participant.get('entities')
 const participantErrors = state => state.participant.get('errors')
-// eslint-disable-next-line import/prefer-default-export
+
+export const getParticipants = createSelector(
+  participantEntities,
+  (participants) => {
+    const [...participantsMapArray] = participants.values()
+    return participantsMapArray.map(participantMap => participantMap.toObject())
+  },
+)
+
 export const getParticipantErrorsArray =
   createSelector(participantErrors, errors => errors.toArray())

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,6 +4271,10 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalizr@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-3.2.4.tgz#16aafc540ca99dc1060ceaa1933556322eac4429"
+
 "npm-package-arg@^3.0.0 || ^4.0.0 || ^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-5.1.2.tgz#fb18d17bb61e60900d6312619919bd753755ab37"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,6 +5194,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"


### PR DESCRIPTION
### Overview:概要
[イベント参加者の一覧を表示する](https://github.com/shinosakarb/tebukuro/issues/205)機能を実装する。
また、normalizr の導入についても本件で検討する。

### Technical changes:技術的変更点
- イベント詳細ページに参加者の一覧をリスト表示するコンポーネント(ParticipantsList)を追加
- normalize パッケージを追加
- normalize したデータを使用するように、action および reducer を修正
- イベントへ参加登録した場合は、参加者名が一覧の最後尾に追加されるようにする

### Impact point:変更に関する影響箇所
- イベント詳細ページで参加者一覧が表示される
- action および reducer についてはファイル構成を含めて、大幅な変更となる

### Change of UserInterface:UIの変更
後ほど追加予定

### Todos
- [x] ParticipantsList コンポーネントを追加
- [x] normalizr パッケージを追加
- [x] ~~Action で normalizr を使用してデータを正規化~~ 
- [x] Reducer および state の構成を normalizr を使用するために変更
- [x] state を Immutable.js の Map で保存するよう変更
- [x] 変更された state に合わせてコンポーネントを修正
- [x] reselect パッケージの導入
- [x] ParticipantsList コンポーネントをイベント表示ページに追加