### PR TITLE
Fix incorrect format params for fetchEvent Action

### DIFF
--- a/pageTests/event/show.spec.js
+++ b/pageTests/event/show.spec.js
@@ -43,10 +43,10 @@ describe('ShowEvent', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('should call fetchEvent once with correct eventId', () => {
+  it('should call fetchEvent once with correct params', () => {
     mount(<ShowEvent {...testProps} />)
 
     expect(testProps.fetchEvent).toHaveBeenCalledTimes(1)
-    expect(testProps.fetchEvent).toBeCalledWith(Params.event1.id)
+    expect(testProps.fetchEvent).toBeCalledWith({ id: Params.event1.id })
   })
 })

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -17,8 +17,8 @@ type Props = {
 
 export class ShowEvent extends Component<Props> {
   componentDidMount() {
-    const eventId = this.props.url.query.id
-    this.props.fetchEvent(eventId)
+    const params = { id: this.props.url.query.id }
+    this.props.fetchEvent(params)
   }
 
   isNotFoundError(errors: ?string[]) {


### PR DESCRIPTION
### Overview:概要
イベント詳細ページで実行する fetchEvent アクションへのパラメータに誤りがあり、エラーとなっている。
このため、イベント詳細ページで与えるパラメータを修正する。

### Technical changes:技術的変更点
fetchEvent アクションへのパラメータを、IDの値のみではなく、キーを指定して与える。
変更前のように、キー `id` を指定しないと、APIモジュール で`id` を指定してバックエンドのURLを作成する際にエラーとなる。
- 変更前： ` 1 ` (イベントのID)
- 変更後： ` { id: 1 }`

このバグの原因は、
- APIモジュールに与えるべきパラメータのフォーマットを確認していなかった
- 現在は単体テストのみ行っており、モジュール間の接続確認は行っていない

点だと考えています。

### Impact point:変更に関する影響箇所
APIモジュールで正しくバックエンドのURLが作成され、イベント詳細ページでバックエンドに接続できるようになる。
動作確認はローカル環境でフロントエンド／バックエンドを接続して確認した。

### Change of UserInterface:UIの変更
変更なし
