### PR TITLE
Upgrade node.js to v8 latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/tebukuro-client
     docker:
-      - image: circleci/node:8.6
+      - image: circleci/node:8
     steps:
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7-alpine
+FROM node:8-alpine
 
 RUN mkdir /client
 WORKDIR /client


### PR DESCRIPTION
### Overview:概要
#### Upgrade node.js
- Docker image v7 latest => v8 latest
- CircleCI image v8.6 => v8 latest
