### PR TITLE
Apply normalize middleware to store

### DIFF
--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -5,6 +5,8 @@ import Router from 'next/router'
 import { Map } from 'immutable'
 import * as Actions from '../event'
 import ActionsType from '../../constants/Actions'
+import EventSchema from '../../schemas/event'
+import ParticipantSchema from '../../schemas/participant'
 
 jest.mock('../../api/index')
 /* eslint-disable import/first */
@@ -51,12 +53,13 @@ describe('EventAction', () => {
         /* eslint-enable */
       })
       it('returns create action with event data.', () => {
-        expect.assertions(2)
+        expect.assertions(3)
         return store.dispatch(Actions.createEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.createEvent)
             expect(action.payload).toEqual(testParam)
+            expect(action.meta.normalizr.schema).toEqual(EventSchema)
           })
       })
 
@@ -105,12 +108,13 @@ describe('EventAction', () => {
         /* eslint-enable */
       })
       it('returns fetch action with event data.', () => {
-        expect.assertions(2)
+        expect.assertions(3)
         return store.dispatch(Actions.fetchEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.fetchEvent)
             expect(action.payload).toEqual(testParam)
+            expect(action.meta.normalizr.schema).toEqual(EventSchema)
           })
       })
     })
@@ -141,12 +145,13 @@ describe('EventAction', () => {
         /* eslint-enable */
       })
       it('returns join action with participant data.', () => {
-        expect.assertions(2)
+        expect.assertions(3)
         return store.dispatch(Actions.registerForEvent(testParam))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.registerForEvent)
             expect(action.payload).toEqual(testParam)
+            expect(action.meta.normalizr.schema).toEqual(ParticipantSchema)
           })
       })
     })

--- a/actions/event.js
+++ b/actions/event.js
@@ -4,10 +4,17 @@ import Router from 'next/router'
 import type { Dispatch } from 'redux'
 import ActionsType from '../constants/Actions'
 import { event, participant } from '../api'
+import EventSchema from '../schemas/event'
+import ParticipantSchema from '../schemas/participant'
 import { getEventId } from '../selectors/event'
 import type { EventProps } from '../types/Event'
 
-const create = createAction(ActionsType.Event.createEvent, event.create)
+const metaCreator = schema => () => (
+  { normalizr: { schema } }
+)
+
+const create =
+  createAction(ActionsType.Event.createEvent, event.create, metaCreator(EventSchema))
 
 // TODO: Return reject in thunk.
 export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState: Function) => (
@@ -17,5 +24,16 @@ export const createEvent = (params: EventProps) => (dispatch: Dispatch, getState
   })
 )
 
-export const fetchEvent = createAction(ActionsType.Event.fetchEvent, event.find)
-export const registerForEvent = createAction(ActionsType.Event.registerForEvent, participant.create)
+export const fetchEvent =
+  createAction(
+    ActionsType.Event.fetchEvent,
+    event.find,
+    metaCreator(EventSchema),
+  )
+
+export const registerForEvent =
+  createAction(
+    ActionsType.Event.registerForEvent,
+    participant.create,
+    metaCreator(ParticipantSchema),
+  )

--- a/middlewares/__tests__/normalizeMiddleware.spec.js
+++ b/middlewares/__tests__/normalizeMiddleware.spec.js
@@ -53,4 +53,18 @@ describe('normalizeMiddleware', () => {
 
     expect(next).toHaveBeenCalledWith(action)
   })
+
+  it('does not normalize when payload is a promise object', () => {
+    const { next, invoke } = create()
+    const action = {
+      type: 'FETCH',
+      payload: Promise.resolve(),
+      meta: {
+        normalizr: { schema: userSchema },
+      },
+    }
+    invoke(action)
+
+    expect(next).toHaveBeenCalledWith(action)
+  })
 })

--- a/middlewares/__tests__/normalizeMiddleware.spec.js
+++ b/middlewares/__tests__/normalizeMiddleware.spec.js
@@ -1,0 +1,56 @@
+import { normalize, schema } from 'normalizr'
+import normalizeMiddleware from '../normalize'
+
+const create = () => {
+  const store = {}
+  const next = jest.fn()
+  const invoke = action => normalizeMiddleware(store)(next)(action)
+  return { store, next, invoke }
+}
+const userSchema = new schema.Entity('users')
+const user = { id: 1, name: 'user' }
+
+describe('normalizeMiddleware', () => {
+  it('normalizes', () => {
+    const { next, invoke } = create()
+    const action = {
+      type: 'FETCH',
+      payload: user,
+      meta: {
+        normalizr: { schema: userSchema },
+      },
+    }
+    invoke(action)
+
+    expect(next).toHaveBeenCalledWith({
+      ...action,
+      payload: normalize(user, userSchema),
+    })
+  })
+
+  it('does not normalize when error reponse', () => {
+    const { next, invoke } = create()
+    const action = {
+      type: 'FETCH',
+      payload: ['error'],
+      error: true,
+      meta: {
+        normalizr: { schema: userSchema },
+      },
+    }
+    invoke(action)
+
+    expect(next).toHaveBeenCalledWith(action)
+  })
+
+  it('does not normalize when no meta option', () => {
+    const { next, invoke } = create()
+    const action = {
+      type: 'FETCH',
+      payload: user,
+    }
+    invoke(action)
+
+    expect(next).toHaveBeenCalledWith(action)
+  })
+})

--- a/middlewares/normalize.js
+++ b/middlewares/normalize.js
@@ -1,0 +1,14 @@
+import { normalize } from 'normalizr'
+
+const canNormalize = action =>
+  !action.error && action.meta && action.meta.normalizr
+
+const normalizeMiddleware = () => next => (action) => {
+  if (canNormalize(action)) {
+    const payload = normalize(action.payload, action.meta.normalizr.schema)
+    return next({ ...action, payload })
+  }
+  return next(action)
+}
+
+export default normalizeMiddleware

--- a/middlewares/normalize.js
+++ b/middlewares/normalize.js
@@ -1,11 +1,13 @@
+// @flow
 import { normalize } from 'normalizr'
+import type { ReduxAction, ActionPayload } from '../types/redux'
 
-const isPromise = payload => payload instanceof Promise
-const canNormalize = action =>
+const isPromise = (payload: ActionPayload) => payload instanceof Promise
+const canNormalize = (action: ReduxAction) =>
   !action.error && action.meta && action.meta.normalizr &&
   !isPromise(action.payload)
 
-const normalizeMiddleware = () => next => (action) => {
+const normalizeMiddleware = () => (next: Function) => (action: ReduxAction) => {
   if (canNormalize(action)) {
     const payload = normalize(action.payload, action.meta.normalizr.schema)
     return next({ ...action, payload })

--- a/middlewares/normalize.js
+++ b/middlewares/normalize.js
@@ -1,7 +1,9 @@
 import { normalize } from 'normalizr'
 
+const isPromise = payload => payload instanceof Promise
 const canNormalize = action =>
-  !action.error && action.meta && action.meta.normalizr
+  !action.error && action.meta && action.meta.normalizr &&
+  !isPromise(action.payload)
 
 const normalizeMiddleware = () => next => (action) => {
   if (canNormalize(action)) {

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -1,4 +1,5 @@
 import { createAction } from 'redux-actions'
+import { normalize } from 'normalizr'
 import { List } from 'immutable'
 
 import EventReducer, { eventInitialState } from '../event'
@@ -6,21 +7,25 @@ import Actions from '../../constants/Actions'
 import ApiResponseError from '../../api/ApiResponseError'
 import EventParams from '../../factories/Event'
 import ParticipantParams from '../../factories/Participant'
+import EventSchema from '../../schemas/event'
+import ParticipantSchema from '../../schemas/participant'
+
+const { participant1 } = ParticipantParams
+const { event1 } = EventParams
+
+const normalizedEvent = normalize(event1, EventSchema)
+const normalizedParticipant = normalize(participant1, ParticipantSchema)
 
 const initialState = eventInitialState
-const testEventParams = EventParams.event1
-const testParticipantParams = ParticipantParams.participant1
-
-const testEventResult = initialState.merge({
-  entityId: testEventParams.id,
-  entities: { [testEventParams.id]: testEventParams },
+const eventMergedState = initialState.merge({
+  entityId: event1.id,
+  entities: { [event1.id]: event1 },
   errors: [],
 })
 
 const error = {
   response: { data: { name: ['を入力して下さい', 'は１０文字以下です'] } },
 }
-
 const errorMessages = new List(['nameを入力して下さい', 'nameは１０文字以下です'])
 
 describe('Event Reducer', () => {
@@ -35,8 +40,8 @@ describe('Event Reducer', () => {
 
     describe('with success event create', () => {
       it('should return created event', () => {
-        const subject = EventReducer(initialState, createEvent(testEventParams))
-        expect(subject).toEqual(testEventResult)
+        const subject = EventReducer(initialState, createEvent(normalizedEvent))
+        expect(subject).toEqual(eventMergedState)
       })
     })
 
@@ -53,8 +58,8 @@ describe('Event Reducer', () => {
 
     describe('with success event fetch', () => {
       it('should return fetched event', () => {
-        const subject = EventReducer(initialState, fetchEvent(testEventParams))
-        expect(subject).toEqual(testEventResult)
+        const subject = EventReducer(initialState, fetchEvent(normalizedEvent))
+        expect(subject).toEqual(eventMergedState)
       })
     })
 
@@ -69,16 +74,16 @@ describe('Event Reducer', () => {
   describe('when REGISTER_FOR_EVENT action', () => {
     const registerForEvent = createAction(Actions.Event.registerForEvent)
 
-    const prevState = testEventResult
+    const prevState = eventMergedState
     const eventId = prevState.get('entityId').toString()
     const nextState = prevState.updateIn(
       ['entities', eventId, 'participants'],
-      participants => participants.push(testParticipantParams.id),
+      participants => participants.push(participant1.id),
     )
 
     describe('with success event register', () => {
       it('should add registered participant', () => {
-        const subject = EventReducer(prevState, registerForEvent(testParticipantParams))
+        const subject = EventReducer(prevState, registerForEvent(normalizedParticipant))
         expect(subject).toEqual(nextState)
       })
     })

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -1,10 +1,8 @@
 // @flow
 import { handleActions } from 'redux-actions'
-import { normalize } from 'normalizr'
 import { Map, List } from 'immutable'
 
 import Actions from '../constants/Actions'
-import EventSchema from '../schemas/event'
 
 export const eventInitialState = new Map({
   entityId: 0,
@@ -12,24 +10,21 @@ export const eventInitialState = new Map({
   errors: new List(),
 })
 
-// TODO: Normalize in Reducer is **NOT** recommended. Need to be refactored.
 const setEvent = {
-  next: (state, action) => {
-    const normalizedPayload = normalize(action.payload, EventSchema)
-
-    return state.merge({
-      entityId: normalizedPayload.result,
-      entities: normalizedPayload.entities.event,
+  next: (state, action) => (
+    state.merge({
+      entityId: action.payload.result,
+      entities: action.payload.entities.event,
       errors: [],
     })
-  },
+  ),
   throw: (state, action) => state.merge({ errors: action.payload.errors }),
 }
 
 const mergeParticipant = {
   next: (state, action) => {
     const eventId = state.get('entityId').toString()
-    const participantId = action.payload.id
+    const participantId = action.payload.result
 
     return state.updateIn(
       ['entities', eventId, 'participants'],

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -1,12 +1,9 @@
 // @flow
 import { handleActions } from 'redux-actions'
-import { normalize } from 'normalizr'
 import { Map, List } from 'immutable'
 import _ from 'lodash'
 
 import Actions from '../constants/Actions'
-import EventSchema from '../schemas/event'
-import ParticipantSchema from '../schemas/participant'
 import ConvertCase from '../utils/ConvertCase'
 
 export const participantInitialState = new Map({
@@ -18,30 +15,23 @@ const toCamelCase = payload => (
   _.mapValues(payload, val => ConvertCase.camelKeysOf(val))
 )
 
-// TODO: Normalize in Reducer is **NOT** recommended. Need to be refactored.
 const participantReducerMap = {
   [Actions.Event.fetchEvent]: {
-    next: (state, action) => {
-      const normalizedPayload = normalize(action.payload, EventSchema)
-      const participant = toCamelCase(normalizedPayload.entities.participant)
-
-      return state.merge({
-        entities: participant,
+    next: (state, action) => (
+      state.merge({
+        entities: toCamelCase(action.payload.entities.participant),
         errors: [],
       })
-    },
+    ),
   },
 
   [Actions.Event.registerForEvent]: {
-    next: (state, action) => {
-      const normalizedPayload = normalize(action.payload, ParticipantSchema)
-      const participant = toCamelCase(normalizedPayload.entities.participant)
-
-      return state.mergeDeep({
-        entities: participant,
+    next: (state, action) => (
+      state.mergeDeep({
+        entities: toCamelCase(action.payload.entities.participant),
         errors: [],
       })
-    },
+    ),
     throw: (state, action) => state.merge({ errors: action.payload.errors }),
   },
 }

--- a/store/index.js
+++ b/store/index.js
@@ -2,9 +2,8 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import promiseMiddleware from 'redux-promise'
 import thunkMiddleware from 'redux-thunk'
-
 import Immutable from 'immutable'
-import Records from '../models'
+import normalizeMiddleware from '../middlewares/normalize'
 import Reducers from '../reducers'
 
 export default (initialState: Object = {}) => {
@@ -16,12 +15,11 @@ export default (initialState: Object = {}) => {
       window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
         serialize: {
           immutable: Immutable,
-          refs: Records,
         },
       }) : compose
   /* eslint-enable */
 
-  const middlewares = [promiseMiddleware, thunkMiddleware]
+  const middlewares = [promiseMiddleware, normalizeMiddleware, thunkMiddleware]
 
   const store = createStore(
     Reducers, initialState,

--- a/types/redux.js
+++ b/types/redux.js
@@ -1,0 +1,6 @@
+// @flow
+import type { Action } from 'redux'
+import type { ThunkAction } from 'redux-thunk'
+
+export type ReduxAction = Action | ThunkAction
+export type ActionPayload = Object | Promise<*, Error>


### PR DESCRIPTION
### Overview:概要
#34 で作成されている normalize middleware を redux の store に追加する。
これにより、Reducer 内での normalize 作業が不要となり、Reducer が純関数でない問題が解消される。

### Technical changes:技術的変更点
以下の変更を実施する。
- Store の `applyMiddleware` に normalize middleware を追加
- Action で、middleware での normalize に必要な schema を meta フィールドで付与
- Reducer で、 normalize 処理を削除し、あらかじめ normalize されているデータを受け取る処理に変更

### Impact point:変更に関する影響箇所
Reducer が純関数でない問題が解消される。

### Change of UserInterface:UIの変更
無し（Redux 内部の処理のため）
