### PR TITLE
Add quota to Event and EventForm Pages

### DIFF
--- a/components/Event/__tests__/EventComponent.spec.js
+++ b/components/Event/__tests__/EventComponent.spec.js
@@ -1,11 +1,16 @@
 import { shallow } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
 import Event from '../index'
-import Params from '../../../factories/Event'
+import EventParams from '../../../factories/Event'
+
+const testParams = {
+  ...EventParams.event1,
+  participants: [1, 2, 3],
+}
 
 describe('Event Component', () => {
   it('renders self.', () => {
-    const component = shallow(<Event event={Params.event1} />)
+    const component = shallow(<Event event={testParams} />)
     const tree = shallowToJson(component)
 
     expect(tree).toMatchSnapshot()

--- a/components/Event/__tests__/__snapshots__/EventComponent.spec.js.snap
+++ b/components/Event/__tests__/__snapshots__/EventComponent.spec.js.snap
@@ -10,5 +10,13 @@ exports[`Event Component renders self. 1`] = `
     description: 
     This is the first event.
   </p>
+  <p>
+    quota: 
+    10
+  </p>
+  <p>
+    number of participants: 
+    3
+  </p>
 </div>
 `;

--- a/components/Event/index.js
+++ b/components/Event/index.js
@@ -6,6 +6,8 @@ const Event = (props: {event: EventProps}) => (
   <div>
     <p>name: {props.event.name}</p>
     <p>description: {props.event.description}</p>
+    <p>quota: {props.event.quota}</p>
+    <p>number of participants: {props.event.participants.length}</p>
   </div>
 )
 

--- a/components/EventForm/__tests__/EventForm.spec.js
+++ b/components/EventForm/__tests__/EventForm.spec.js
@@ -2,11 +2,12 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
 import EventForm from '../index'
-import Params from '../../../factories/Event'
+import EventParams from '../../../factories/Event'
 
 const inputValues = {
-  name: Params.event1.name,
-  description: Params.event1.description,
+  name: EventParams.event1.name,
+  description: EventParams.event1.description,
+  quota: EventParams.event1.quota,
 }
 
 describe('EventForm', () => {
@@ -22,8 +23,9 @@ describe('EventForm', () => {
       const onSubmit = jest.fn()
       const wrapper = mount(<EventForm onSubmit={onSubmit} />)
 
-      const nameElement = wrapper.find('[type="text"]')
-      const descriptionElement = wrapper.find('textarea')
+      const nameElement = wrapper.find('#name')
+      const descriptionElement = wrapper.find('#description')
+      const quotaElement = wrapper.find('#quota')
 
       nameElement.simulate(
         'change',
@@ -32,6 +34,10 @@ describe('EventForm', () => {
       descriptionElement.simulate(
         'change',
         { target: { id: 'description', value: inputValues.description } },
+      )
+      quotaElement.simulate(
+        'change',
+        { target: { id: 'quota', value: inputValues.quota } },
       )
       wrapper.find('[type="submit"]').simulate('submit')
 

--- a/components/EventForm/__tests__/__snapshots__/EventForm.spec.js.snap
+++ b/components/EventForm/__tests__/__snapshots__/EventForm.spec.js.snap
@@ -34,6 +34,19 @@ exports[`EventForm render event form component 1`] = `
       </label>
     </div>
     <div>
+      <label
+        htmlFor="quota"
+      >
+        quota
+        <input
+          id="quota"
+          onChange={[Function]}
+          type="number"
+          value={0}
+        />
+      </label>
+    </div>
+    <div>
       <input
         type="submit"
       />

--- a/components/EventForm/index.js
+++ b/components/EventForm/index.js
@@ -4,13 +4,14 @@ import React, { Component } from 'react'
 type Props = { onSubmit: Function }
 type State = {
   name: string,
-  description: string
+  description: string,
+  quota: number
 }
 
 export default class EventForm extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { name: '', description: '' }
+    this.state = { name: '', description: '', quota: 0 }
   }
 
   onChangeHandler = (e: SyntheticInputEvent<>) => {
@@ -41,6 +42,12 @@ export default class EventForm extends Component<Props, State> {
             <label htmlFor="description">
               description
               <textarea id="description" value={this.state.description} onChange={this.onChangeHandler} />
+            </label>
+          </div>
+          <div>
+            <label htmlFor="quota">
+              quota
+              <input type="number" id="quota" value={this.state.quota} onChange={this.onChangeHandler} />
             </label>
           </div>
           <div>

--- a/factories/Event.js
+++ b/factories/Event.js
@@ -3,6 +3,7 @@ export default {
     id: 1,
     name: 'event1',
     description: 'This is the first event.',
+    quota: 10,
     participants: [],
   },
   errorEvent: {

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -12,6 +12,7 @@ exports[`ShowEvent renders the event page. 1`] = `
         "id": 1,
         "name": "event1",
         "participants": Array [],
+        "quota": 10,
       }
     }
   />

--- a/selectors/__tests__/EventSelector.spec.js
+++ b/selectors/__tests__/EventSelector.spec.js
@@ -7,7 +7,7 @@ const errorMessages = ['nameを入力して下さい', 'nameは１０文字以�
 
 const testEventState = new Map({
   entityId: eventId,
-  entities: new Map({ [eventId]: new Map(EventParams.event1) }),
+  entities: new Map({ [eventId]: new Map().merge(EventParams.event1) }),
   errors: new List(errorMessages),
 })
 const mockState = { event: testEventState }

--- a/selectors/event.js
+++ b/selectors/event.js
@@ -8,5 +8,11 @@ export const getEventId = (state: Object) => state.event.get('entityId')
 export const getEventErrorsArray = createSelector(getEventErrors, errors => errors.toArray())
 export const getCurrentEvent = createSelector(
   [getEventId, getEventEntities],
-  (id, entities) => entities.get(id.toString()).toObject(),
+  (id, entities) => {
+    const entitiesObject = entities.get(id.toString()).toObject()
+    return {
+      ...entitiesObject,
+      participants: entitiesObject.participants.toArray(),
+    }
+  },
 )

--- a/types/Event.js
+++ b/types/Event.js
@@ -8,5 +8,7 @@ export type EventProps = {
   id: ?number,
   name: string,
   description: string,
+  quota: number,
+  participants: Object[],
   errors: ?string[]
 }


### PR DESCRIPTION
### Overview:概要
イベントで定員を設定することに伴い、以下の機能を追加する
- イベント作成ページで定員を設定する
- イベント詳細ページで定員および申し込み人数を表示

### Technical changes:技術的変更点
- イベント作成ページで定員を設定する
  - EventForm コンポーネントに定員を設定するフォームを `type=number` の input要素として追加
  - EventForm の local state に quota を追加し、初期値に 0 を設定
（`type=number` の input要素は必ず数字である必要があり、入力漏れを防ぐため有効でない数字０を設定）

- イベント詳細ページで定員および申し込み人数を表示
  - Event コンポーネントで`event` プロパティから定員および申し込み人数を取得
    - 定員： `quota`フィールド
    - 申し込み人数： 配列である`participants`フィールドの`length`
    - `event` の `participants`フィールドは Store では Immutable.js の List として保存されているため、 Selector で JS標準の Array に変換してコンポーネントに渡す処理を追加

### Impact point:変更に関する影響箇所
イベントのテスト用のパラメータに`quota` フィールドを追加したことで、本PRとは直接関係何 イベント詳細ページのスナップショットが変更となっています。

### Change of UserInterface:UIの変更
変更前と変更後のスクリーンショット

### Todos
- [x]  イベント作成ページで定員を設定する
- [x] イベント詳細ページで定員および申し込み人数を表示