### PR TITLE
Add cancel registration feature to event show page

### DIFF
--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -9,9 +9,8 @@ import EventSchema from '../../schemas/event'
 import ParticipantSchema from '../../schemas/participant'
 
 jest.mock('../../api/index')
-/* eslint-disable import/first */
+// eslint-disable-next-line import/first
 import mockAPI from '../../api/index'
-/* eslint-enable */
 
 const testParam = new Map({ entityId: 1 })
 
@@ -48,9 +47,8 @@ describe('EventAction', () => {
 
     describe('when successes to create the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
-        /* eslint-enable */
       })
       it('returns create action with event data.', () => {
         expect.assertions(3)
@@ -75,9 +73,8 @@ describe('EventAction', () => {
 
     describe('when fails to create the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(false)
-        /* eslint-enable */
       })
       it('returns create action with instance of Error.', () => {
         expect.assertions(2)
@@ -103,9 +100,8 @@ describe('EventAction', () => {
   describe('fetchEvent', () => {
     describe('when successes to fetch the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
-        /* eslint-enable */
       })
       it('returns fetch action with event data.', () => {
         expect.assertions(3)
@@ -121,9 +117,8 @@ describe('EventAction', () => {
 
     describe('when fails to fetch the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(false)
-        /* eslint-enable */
       })
       it('returns fetch action with instance of Error.', () => {
         expect.assertions(2)
@@ -140,9 +135,8 @@ describe('EventAction', () => {
   describe('registerForEvent', () => {
     describe('when successes to join the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
-        /* eslint-enable */
       })
       it('returns join action with participant data.', () => {
         expect.assertions(3)
@@ -158,13 +152,47 @@ describe('EventAction', () => {
 
     describe('when fails to join the Event', () => {
       beforeEach(() => {
-        /* eslint-disable no-underscore-dangle */
+        // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(false)
-        /* eslint-enable */
       })
       it('returns join action with instance of Error.', () => {
         expect.assertions(2)
         return store.dispatch(Actions.registerForEvent(testParam))
+          .then(() => {
+            const action = store.getActions()[0]
+            expect(action.type).toBe(ActionsType.Event.registerForEvent)
+            expect(action.payload).toBeInstanceOf(Error)
+          })
+      })
+    })
+  })
+
+  describe('cancelRegistration', () => {
+    const cancelTestParams = { id: 1, eventId: 1 }
+    describe('when successes to cancel Registraion', () => {
+      beforeEach(() => {
+        // eslint-disable-next-line no-underscore-dangle
+        mockAPI.__setMockResult(true)
+      })
+      it('returns cancel regstration action with participant data.', () => {
+        expect.assertions(2)
+        return store.dispatch(Actions.registerForEvent(cancelTestParams))
+          .then(() => {
+            const action = store.getActions()[0]
+            expect(action.type).toBe(ActionsType.Event.registerForEvent)
+            expect(action.payload).toEqual(cancelTestParams)
+          })
+      })
+    })
+
+    describe('when fails to cancel Registration', () => {
+      beforeEach(() => {
+        // eslint-disable-next-line no-underscore-dangle
+        mockAPI.__setMockResult(false)
+      })
+      it('returns join action with instance of Error.', () => {
+        expect.assertions(2)
+        return store.dispatch(Actions.registerForEvent(cancelTestParams))
           .then(() => {
             const action = store.getActions()[0]
             expect(action.type).toBe(ActionsType.Event.registerForEvent)

--- a/actions/event.js
+++ b/actions/event.js
@@ -37,3 +37,8 @@ export const registerForEvent =
     participant.create,
     metaCreator(ParticipantSchema),
   )
+
+export const cancelRegistration = createAction(
+  ActionsType.Event.cancelRegistration,
+  participant.delete,
+)

--- a/api/__mocks__/index.js
+++ b/api/__mocks__/index.js
@@ -1,11 +1,10 @@
 const api = jest.genMockFromModule('../index')
 
 let mockResult = Object.create(null)
-/* eslint-disable no-underscore-dangle */
+// eslint-disable-next-line no-underscore-dangle
 export const __setMockResult = (normal = true) => {
   mockResult = normal
 }
-/* eslint-enable */
 
 const mockedPromise = params => (
   mockResult ? Promise.resolve(params) : Promise.reject(new Error())
@@ -18,11 +17,11 @@ export const event = {
 
 export const participant = {
   create: mockedPromise,
+  delete: mockedPromise,
 }
 
-/* eslint-disable no-underscore-dangle */
+// eslint-disable-next-line no-underscore-dangle
 api.__setMockResult = __setMockResult
-/* eslint-enable */
 api.event = event
 api.participant = participant
 

--- a/components/Participant/__tests__/Participant.spec.js
+++ b/components/Participant/__tests__/Participant.spec.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import shallowToJson from 'enzyme-to-json'
+import Participant from '../index'
+
+const testProps = {
+  id: 1,
+  eventId: 2,
+  name: 'Participant 1',
+}
+
+describe('Participant', () => {
+  it('renders participant component', () => {
+    const wrapper = shallow(<Participant {...testProps} onCancel={jest.fn()} />)
+    const tree = shallowToJson(wrapper)
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  describe('when clicked', () => {
+    const onCancel = jest.fn()
+    const wrapper = mount(<Participant {...testProps} onCancel={onCancel} />)
+
+    wrapper.find('button').simulate('click')
+
+    it('should call onCancel once.', () => {
+      expect(onCancel).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onCancel with correct argument.', () => {
+      expect(onCancel).toBeCalledWith({
+        id: testProps.id,
+        eventId: testProps.eventId,
+      })
+    })
+  })
+})

--- a/components/Participant/__tests__/__snapshots__/Participant.spec.js.snap
+++ b/components/Participant/__tests__/__snapshots__/Participant.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participant renders participant component 1`] = `
+<div>
+  Participant 1
+  <button
+    onClick={[Function]}
+  >
+    cancel
+  </button>
+</div>
+`;

--- a/components/Participant/index.js
+++ b/components/Participant/index.js
@@ -1,0 +1,30 @@
+// @flow
+import React, { Component } from 'react'
+
+type Props = {
+  id: number,
+  eventId: number,
+  name: string,
+  onCancel: Function,
+}
+
+export default class Participant extends Component<Props> {
+  onCancelHandler = (e: SyntheticEvent<>) => {
+    e.preventDefault()
+    this.props.onCancel({
+      id: this.props.id,
+      eventId: this.props.eventId,
+    })
+  }
+
+  render() {
+    return (
+      <div>
+        { this.props.name }
+        <button onClick={this.onCancelHandler} >
+          cancel
+        </button>
+      </div>
+    )
+  }
+}

--- a/components/Participant/index.js
+++ b/components/Participant/index.js
@@ -9,8 +9,7 @@ type Props = {
 }
 
 export default class Participant extends Component<Props> {
-  onCancelHandler = (e: SyntheticEvent<>) => {
-    e.preventDefault()
+  onCancelHandler = () => {
     this.props.onCancel({
       id: this.props.id,
       eventId: this.props.eventId,

--- a/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
+++ b/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
@@ -6,12 +6,20 @@ exports[`ParticipantList Component renders self. 1`] = `
     <li
       key="1"
     >
-      participant1
+      <Participant
+        eventId={1}
+        id={1}
+        name="participant1"
+      />
     </li>
     <li
       key="2"
     >
-      participant2
+      <Participant
+        eventId={1}
+        id={2}
+        name="participant2"
+      />
     </li>
   </ul>
 </div>

--- a/components/ParticipantsList/index.js
+++ b/components/ParticipantsList/index.js
@@ -1,15 +1,24 @@
 // @flow
 import React from 'react'
+import ParticipantComponent from '../Participant'
 
-const ParticipantList = (props: {participants: ?Object[]}) => (
+type Props = {
+  participants: ?Object[],
+  onCancel: Function,
+}
+
+const ParticipantsList = (props: Props) => (
   <div>
     { props.participants &&
       <ul>
-        { props.participants.map(participant =>
-          <li key={participant.id}>{ participant.name }</li>)}
+        { props.participants.map(participant => (
+          <li key={participant.id}>
+            <ParticipantComponent {...participant} onCancel={props.onCancel} />
+          </li>
+        ))}
       </ul>
     }
   </div>
 )
 
-export default ParticipantList
+export default ParticipantsList

--- a/constants/Actions.js
+++ b/constants/Actions.js
@@ -3,6 +3,7 @@ export default {
     createEvent: 'CREATE_EVENT',
     fetchEvent: 'FETCH_EVENT',
     registerForEvent: 'REGISTER_FOR_EVENT',
+    cancelRegistration: 'CANCEL_REGISTRATION',
   },
 }
 

--- a/constants/endpoints.js
+++ b/constants/endpoints.js
@@ -8,4 +8,5 @@ export const event = {
 
 export const participant = {
   create: '/events/:eventId/participants',
+  delete: '/events/:eventId/participants/:id',
 }

--- a/pageTests/event/__snapshots__/show.spec.js.snap
+++ b/pageTests/event/__snapshots__/show.spec.js.snap
@@ -19,7 +19,7 @@ exports[`ShowEvent renders the event page. 1`] = `
     eventId={1}
     onSubmit={[Function]}
   />
-  <ParticipantList
+  <ParticipantsList
     participants={
       Array [
         Object {
@@ -62,7 +62,7 @@ exports[`ShowEvent renders the page with error messages. 1`] = `
   <ParticipantForm
     onSubmit={[Function]}
   />
-  <ParticipantList
+  <ParticipantsList
     participants={
       Array [
         Object {

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import withRedux from 'next-redux-wrapper'
 import Error from 'next/error'
 import createStore from '../../store'
-import { fetchEvent, registerForEvent } from '../../actions/event'
+import { fetchEvent, registerForEvent, cancelRegistration } from '../../actions/event'
 import { getCurrentEvent } from '../../selectors/event'
 import { getParticipants, getParticipantErrorsArray } from '../../selectors/participant'
 import EventComponent from '../../components/Event'
@@ -18,6 +18,7 @@ type Props = {
   participantErrors: ?string[],
   fetchEvent: Function,
   registerForEvent: Function,
+  cancelRegistration: Function,
 }
 
 export class ShowEvent extends Component<Props> {
@@ -46,7 +47,10 @@ export class ShowEvent extends Component<Props> {
           eventId={event.id}
           errors={this.props.participantErrors}
         />
-        <ParticipantsListComponent participants={this.props.participants} />
+        <ParticipantsListComponent
+          participants={this.props.participants}
+          onCancel={this.props.cancelRegistration}
+        />
       </div>
     )
   }
@@ -58,7 +62,7 @@ const mapStateToProps = state => ({
   participantErrors: getParticipantErrorsArray(state),
 })
 
-const mapDispatchToProps = { fetchEvent, registerForEvent }
+const mapDispatchToProps = { fetchEvent, registerForEvent, cancelRegistration }
 
 const connectProps = {
   createStore,

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -95,4 +95,29 @@ describe('Event Reducer', () => {
       })
     })
   })
+
+  describe('when CANCEL_REGISTRATION action', () => {
+    const cancelRegistration = createAction(Actions.Event.cancelRegistration)
+
+    const eventId = eventMergedState.get('entityId').toString()
+    const prevState = eventMergedState.updateIn(
+      ['entities', eventId, 'participants'],
+      participants => participants.push(participant1.id),
+    )
+    const nextState = eventMergedState
+
+    describe('with success cancel registration', () => {
+      it('should delete registered participant', () => {
+        const subject = EventReducer(prevState, cancelRegistration(participant1))
+        expect(subject).toEqual(nextState)
+      })
+    })
+
+    describe('with failure cancel registration', () => {
+      it('should keep previous state', () => {
+        const subject = EventReducer(prevState, cancelRegistration(new ApiResponseError(error)))
+        expect(subject).toEqual(prevState)
+      })
+    })
+  })
 })

--- a/reducers/__tests__/ParticipantReducer.spec.js
+++ b/reducers/__tests__/ParticipantReducer.spec.js
@@ -82,4 +82,30 @@ describe('Participant Reducer', () => {
       })
     })
   })
+
+  describe('when CANCEL_REGISTRATION action', () => {
+    const cancelRegistration = createAction(Actions.Event.cancelRegistration)
+
+    describe('with success cancel registration', () => {
+      it('should delete registered participant', () => {
+        const participantParams = ConvertCase.snakeKeysOf(participant2)
+        const prevState = participantMergedState.mergeDeep({ entities: participantEntity2 })
+        const subject = ParticipantReducer(
+          prevState,
+          cancelRegistration(participantParams),
+        )
+        const nextState = participantMergedState
+
+        expect(subject).toEqual(nextState)
+      })
+    })
+
+    describe('with failure cancel registration', () => {
+      it('should return error message', () => {
+        const subject =
+          ParticipantReducer(initialState, cancelRegistration(new ApiResponseError(error)))
+        expect(subject.get('errors')).toEqual(errorMessages)
+      })
+    })
+  })
 })

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -33,10 +33,23 @@ const mergeParticipant = {
   },
 }
 
+const deleteParticipant = {
+  next: (state, action) => {
+    const eventId = state.get('entityId').toString()
+    const participantId = action.payload.id
+
+    return state.updateIn(
+      ['entities', eventId, 'participants'],
+      participants => participants.filter(id => id !== participantId),
+    )
+  },
+}
+
 const eventReducerMap = {
   [Actions.Event.createEvent]: setEvent,
   [Actions.Event.fetchEvent]: setEvent,
   [Actions.Event.registerForEvent]: mergeParticipant,
+  [Actions.Event.cancelRegistration]: deleteParticipant,
 }
 
 export default handleActions(eventReducerMap, eventInitialState)

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -34,6 +34,16 @@ const participantReducerMap = {
     ),
     throw: (state, action) => state.merge({ errors: action.payload.errors }),
   },
+
+  [Actions.Event.cancelRegistration]: {
+    next: (state, action) => (
+      state.merge({
+        entities: state.get('entities').delete(action.payload.id.toString()),
+        errors: [],
+      })
+    ),
+    throw: (state, action) => state.merge({ errors: action.payload.errors }),
+  },
 }
 
 export default handleActions(participantReducerMap, participantInitialState)


### PR DESCRIPTION
### Overview:概要
イベントへの参加登録をキャンセルする機能を追加し、イベント詳細ページで「キャンセル」ボタンを配置する。

### Technical changes:技術的変更点
- 参加登録キャンセルの Action `CANCEL_REGISTRAION` を追加
- API で参加者を削除するリクエストをバックエンドのエンドポイント `/events/:event_id/participants/:id に送信
- Event Reducer、Participant Reducer でバックエンドから返された参加者を Store から削除
- イベント詳細のページの参加者一覧で、参加者名の横にキャンセルボタンを配置、`CANCEL_REGISTRATION` アクションと接続

### Impact point:変更に関する影響箇所
現時点ではユーザー認証を実装していないため、誰でも参加者の登録キャンセルが可能となる。

### Change of UserInterface:UIの変更
最終的な画面イメージ：
![_007](https://user-images.githubusercontent.com/10824691/34318196-d388b9b4-e804-11e7-9094-488ffa34fb28.png)

### TODOs
- [x] `CANCEL_REGISTRAION` アクションの追加
- [x] エンドポイント `/events/:event_id/participants/:id を追加
- [x] Event Reducer、Participant Reducer で対象の参加者を Store から削除する処理の追加
- [x] Participant Component を作成し、ParticipantsList Componentで使用
- [x] イベント詳細のページの参加者名の横にキャンセルボタンを配置、`CANCEL_REGISTRATION` アクションと接続

