### PR TITLE
Frontend validation with validatorjs package

### DIFF
--- a/actions/__tests__/EventFormAction.spec.js
+++ b/actions/__tests__/EventFormAction.spec.js
@@ -1,0 +1,21 @@
+import { validateEventForm } from '../eventForm'
+import ActionsType from '../../constants/Actions'
+
+const testParams = {
+  id: 'name',
+  value: '',
+}
+
+describe('EventFormAction', () => {
+  describe('validateEventForm', () => {
+    it('returns validate action with validation result.', () => {
+      const action = validateEventForm(testParams.id, testParams.value)
+      const { type, payload } = action
+
+      expect(type).toEqual(ActionsType.EventForm.validateEventParam)
+      expect(payload.id).toEqual(testParams.id)
+      expect(payload.validationPassed).toEqual(false)
+      expect(payload.errors).toEqual(['nameは必須です。'])
+    })
+  })
+})

--- a/actions/eventForm.js
+++ b/actions/eventForm.js
@@ -1,0 +1,8 @@
+// @flow
+import { createAction } from 'redux-actions'
+import ActionsType from '../constants/Actions'
+import eventFormValidator from '../validators/eventFormValidator'
+
+// eslint-disable-next-line import/prefer-default-export
+export const validateEventForm =
+  createAction(ActionsType.EventForm.validateEventParam, eventFormValidator)

--- a/components/EventForm/__tests__/EventForm.spec.js
+++ b/components/EventForm/__tests__/EventForm.spec.js
@@ -10,23 +10,55 @@ const inputValues = {
   quota: EventParams.event1.quota,
 }
 
+const testProps = {
+  onSubmit: jest.fn(),
+  onValidation: jest.fn(),
+  validationErrors: { name: ['nameは必須です。'] },
+  validationFailed: false,
+}
+
 describe('EventForm', () => {
   it('render event form component', () => {
-    const wrapper = shallow(<EventForm onSubmit={jest.fn()} />)
+    const wrapper = shallow(<EventForm {...testProps} />)
     const tree = shallowToJson(wrapper)
 
     expect(tree).toMatchSnapshot()
   })
 
-  describe('when submit', () => {
-    describe('with correct argument', () => {
-      const onSubmit = jest.fn()
-      const wrapper = mount(<EventForm onSubmit={onSubmit} />)
+  describe('form fields', () => {
+    beforeEach(() => {
+      testProps.onValidation.mockReset()
+    })
 
-      const nameElement = wrapper.find('input#name')
-      const descriptionElement = wrapper.find('input#description')
-      const quotaElement = wrapper.find('input#quota')
+    const wrapper = mount(<EventForm {...testProps} />)
 
+    const nameElement = wrapper.find('input#name')
+    const descriptionElement = wrapper.find('input#description')
+    const quotaElement = wrapper.find('input#quota')
+
+    describe('when field value changed', () => {
+      it('should call onValidation once.', () => {
+        nameElement.simulate(
+          'change',
+          { target: { id: 'name', value: inputValues.name } },
+        )
+
+        expect(testProps.onValidation).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when field lost focus', () => {
+      it('should call onValidation once.', () => {
+        nameElement.simulate(
+          'blur',
+          { target: { id: 'name', value: inputValues.name } },
+        )
+
+        expect(testProps.onValidation).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when submit params', () => {
       nameElement.simulate(
         'change',
         { target: { id: 'name', value: inputValues.name } },
@@ -42,11 +74,11 @@ describe('EventForm', () => {
       wrapper.find('[type="submit"]').simulate('submit')
 
       it('should call onSubmit once.', () => {
-        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(testProps.onSubmit).toHaveBeenCalledTimes(1)
       })
 
-      it('should call onSubmit with correct argument.', () => {
-        expect(onSubmit).toBeCalledWith(inputValues)
+      it('should call onSubmit with correct params.', () => {
+        expect(testProps.onSubmit).toBeCalledWith(inputValues)
       })
     })
   })

--- a/components/EventForm/__tests__/__snapshots__/EventForm.spec.js.snap
+++ b/components/EventForm/__tests__/__snapshots__/EventForm.spec.js.snap
@@ -9,21 +9,30 @@ exports[`EventForm render event form component 1`] = `
     onSubmit={[Function]}
   >
     <Component
+      errorMessages={
+        Array [
+          "nameは必須です。",
+        ]
+      }
       id="name"
+      onBlur={[Function]}
       onChange={[Function]}
       value=""
     />
     <Component
       id="description"
+      onBlur={[Function]}
       onChange={[Function]}
       value=""
     />
     <Component
       id="quota"
+      onBlur={[Function]}
       onChange={[Function]}
       value={0}
     />
     <input
+      disabled={false}
       type="submit"
     />
   </form>

--- a/components/EventForm/index.js
+++ b/components/EventForm/index.js
@@ -2,7 +2,12 @@
 import React, { Component } from 'react'
 import TextInputField from '../forms/TextInputField'
 
-type Props = { onSubmit: Function }
+type Props = {
+  onSubmit: Function,
+  onValidation: Function,
+  validationErrors: Object,
+  validationFailed: boolean,
+}
 type State = {
   name: string,
   description: string,
@@ -15,11 +20,18 @@ export default class EventForm extends Component<Props, State> {
     this.state = { name: '', description: '', quota: 0 }
   }
 
+  onBlurHandler = (e: SyntheticInputEvent<>) => {
+    const { id, value } = e.target
+    this.props.onValidation(id, value)
+  }
+
   onChangeHandler = (e: SyntheticInputEvent<>) => {
+    const { id, value } = e.target
     this.setState({
       ...this.state,
-      [e.target.id]: e.target.value,
+      [id]: value,
     })
+    this.props.onValidation(id, value)
   }
 
   onSubmitHandler = (e: SyntheticEvent<>) => {
@@ -32,10 +44,28 @@ export default class EventForm extends Component<Props, State> {
       <div>
         <h3>Event registration form</h3>
         <form onSubmit={this.onSubmitHandler}>
-          <TextInputField id="name" value={this.state.name} onChange={this.onChangeHandler} />
-          <TextInputField id="description" value={this.state.description} onChange={this.onChangeHandler} />
-          <TextInputField id="quota" value={this.state.quota} onChange={this.onChangeHandler} />
-          <input type="submit" />
+          <TextInputField
+            id="name"
+            value={this.state.name}
+            onChange={this.onChangeHandler}
+            onBlur={this.onBlurHandler}
+            errorMessages={this.props.validationErrors.name}
+          />
+          <TextInputField
+            id="description"
+            value={this.state.description}
+            onChange={this.onChangeHandler}
+            onBlur={this.onBlurHandler}
+            errorMessages={this.props.validationErrors.description}
+          />
+          <TextInputField
+            id="quota"
+            value={this.state.quota}
+            onChange={this.onChangeHandler}
+            onBlur={this.onBlurHandler}
+            errorMessages={this.props.validationErrors.quota}
+          />
+          <input type="submit" disabled={this.props.validationFailed} />
         </form>
       </div>
     )

--- a/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
@@ -9,7 +9,9 @@ exports[`ParticipantForm renders participant form component 1`] = `
     onSubmit={[Function]}
   >
     <Component
+      errorMessages={Array []}
       id="name"
+      onBlur={[Function]}
       onChange={[Function]}
       value=""
     />
@@ -28,7 +30,9 @@ exports[`ParticipantForm renders participant form component with completion mess
     onSubmit={[Function]}
   >
     <Component
+      errorMessages={Array []}
       id="name"
+      onBlur={[Function]}
       onChange={[Function]}
       value=""
     />
@@ -51,7 +55,9 @@ exports[`ParticipantForm renders participant form component with error message 1
     onSubmit={[Function]}
   >
     <Component
+      errorMessages={Array []}
       id="name"
+      onBlur={[Function]}
       onChange={[Function]}
       value=""
     />

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -48,7 +48,13 @@ export default class ParticipantForm extends Component<Props, State> {
         }
         { this.props.message }
         <form onSubmit={this.onSubmitHandler}>
-          <TextInputField id="name" value={this.state.name} onChange={this.onChangeHandler} />
+          <TextInputField
+            id="name"
+            value={this.state.name}
+            onChange={this.onChangeHandler}
+            onBlur={() => {}}
+            errorMessages={[]}
+          />
           <ParticipantButton hasEventWaitlist={this.props.hasEventWaitlist} />
         </form>
       </div>

--- a/components/forms/TextInputField/__tests__/TextInputField.spec.js
+++ b/components/forms/TextInputField/__tests__/TextInputField.spec.js
@@ -7,6 +7,8 @@ const testProps = {
   id: 'name',
   value: 'event1',
   onChange: jest.fn(),
+  onBlur: jest.fn(),
+  errorMessages: ['nameは必須です。'],
 }
 
 describe('TextInput', () => {

--- a/components/forms/TextInputField/__tests__/__snapshots__/TextInputField.spec.js.snap
+++ b/components/forms/TextInputField/__tests__/__snapshots__/TextInputField.spec.js.snap
@@ -7,11 +7,28 @@ exports[`TextInput render event form component 1`] = `
   >
     name
     <input
+      errorMessages={
+        Array [
+          "nameは必須です。",
+        ]
+      }
       id="name"
+      onBlur={[Function]}
       onChange={[Function]}
       type="text"
       value="event1"
     />
+    <span
+      style={
+        Object {
+          "color": "red",
+          "fontSize": "13px",
+          "paddingLeft": "5px",
+        }
+      }
+    >
+      nameは必須です。
+    </span>
   </label>
 </div>
 `;

--- a/components/forms/TextInputField/index.js
+++ b/components/forms/TextInputField/index.js
@@ -5,6 +5,8 @@ type Props = {
   id: string,
   value: string | number,
   onChange: Function,
+  onBlur: Function,
+  errorMessages: ?[],
 }
 
 export default (props: Props) => (
@@ -12,6 +14,9 @@ export default (props: Props) => (
     <label htmlFor={props.id}>
       { props.id }
       <input type="text" {...props} />
+      <span style={{ color: 'red', fontSize: '13px', paddingLeft: '5px' }} >
+        { props.errorMessages }
+      </span>
     </label>
   </div>
 )

--- a/constants/Actions.js
+++ b/constants/Actions.js
@@ -5,5 +5,8 @@ export default {
     registerForEvent: 'REGISTER_FOR_EVENT',
     cancelRegistration: 'CANCEL_REGISTRATION',
   },
+  EventForm: {
+    validateEventParam: 'VALIDATE_EVENT_PARAM',
+  },
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "redux-actions": "^2.2.1",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1"
+    "reselect": "^3.0.1",
+    "validatorjs": "^3.14.2"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.3",

--- a/pageTests/event/__snapshots__/new.spec.js.snap
+++ b/pageTests/event/__snapshots__/new.spec.js.snap
@@ -7,6 +7,14 @@ exports[`NewEvent on first page load renders the new event page without error me
   </h3>
   <EventFormComponent
     onSubmit={[Function]}
+    onValidation={[Function]}
+    validationErrors={
+      Object {
+        "name": Array [],
+        "quota": Array [],
+      }
+    }
+    validationFailed={false}
   />
 </div>
 `;
@@ -26,6 +34,14 @@ exports[`NewEvent on submit invalid inputs renders the new event page without er
   </ul>
   <EventFormComponent
     onSubmit={[Function]}
+    onValidation={[Function]}
+    validationErrors={
+      Object {
+        "name": Array [],
+        "quota": Array [],
+      }
+    }
+    validationFailed={false}
   />
 </div>
 `;

--- a/pageTests/event/new.spec.js
+++ b/pageTests/event/new.spec.js
@@ -8,14 +8,17 @@ jest.mock('../../actions/event', () => ({
   createEvent: () => {},
 }))
 
+const testProps = {
+  createEvent: jest.fn(),
+  validateEventForm: jest.fn(),
+  errors: null,
+  validationErrors: { name: [], quota: [] },
+  validationFailed: false,
+}
+
 describe('NewEvent', () => {
   describe('on first page load', () => {
     it('renders the new event page without error messages.', () => {
-      const testProps = {
-        createEvent: jest.fn(),
-        errors: null,
-      }
-
       const page = shallow(<NewEvent {...testProps} />)
       const tree = shallowToJson(page)
 
@@ -24,12 +27,12 @@ describe('NewEvent', () => {
   })
   describe('on submit invalid inputs', () => {
     it('renders the new event page without error messages.', () => {
-      const testProps = {
-        createEvent: jest.fn(),
+      const errorTestProps = {
+        ...testProps,
         errors: Params.errorEvent.errors,
       }
 
-      const page = shallow(<NewEvent {...testProps} />)
+      const page = shallow(<NewEvent {...errorTestProps} />)
       const tree = shallowToJson(page)
 
       expect(tree).toMatchSnapshot()

--- a/pages/event/new.js
+++ b/pages/event/new.js
@@ -3,11 +3,16 @@ import React from 'react'
 import withRedux from 'next-redux-wrapper'
 import createStore from '../../store'
 import { createEvent } from '../../actions/event'
+import { validateEventForm } from '../../actions/eventForm'
 import { getEventErrorsArray } from '../../selectors/event'
+import { getValidationErrorMessages, isValidationFailed } from '../../selectors/eventForm'
 import EventFormComponent from '../../components/EventForm'
 
 type EventFormProps = {
   createEvent: Function,
+  validateEventForm: Function,
+  validationErrors: Object,
+  validationFailed: boolean,
   errors: ?string[]
 }
 
@@ -15,19 +20,29 @@ export const NewEvent = (props: EventFormProps) => (
   <div>
     <h3>This is the event form page!</h3>
     { props.errors &&
-      <ul>
-        { props.errors.map(error =>
-          <li>{ error }</li>)}
-      </ul>
-    }
-    <EventFormComponent onSubmit={props.createEvent} />
+    <ul>
+      { props.errors.map(error =>
+        <li>{ error }</li>)}
+    </ul>
+      }
+    <EventFormComponent
+      onSubmit={props.createEvent}
+      onValidation={props.validateEventForm}
+      validationErrors={props.validationErrors}
+      validationFailed={props.validationFailed}
+    />
   </div>
 )
 
-const mapDispatchToProps = { createEvent }
-const mapStateToProps = state => (
-  { errors: getEventErrorsArray(state) }
-)
+const mapDispatchToProps = {
+  createEvent,
+  validateEventForm,
+}
+const mapStateToProps = state => ({
+  errors: getEventErrorsArray(state),
+  validationErrors: getValidationErrorMessages(state),
+  validationFailed: isValidationFailed(state),
+})
 
 const connectProps = {
   createStore,

--- a/reducers/__tests__/EventFormReducer.js
+++ b/reducers/__tests__/EventFormReducer.js
@@ -1,0 +1,34 @@
+import { createAction } from 'redux-actions'
+
+import EventFormReducer, { eventFormInitialState } from '../eventForm'
+import Actions from '../../constants/Actions'
+
+const testParams = {
+  id: 'name',
+  validationPassed: false,
+  errors: ['nameは必須です。'],
+}
+
+describe('EventFormReducer', () => {
+  describe('when initial state', () => {
+    it('should return the initial state', () => {
+      expect(EventFormReducer(undefined, {})).toEqual(eventFormInitialState)
+    })
+  })
+
+  describe('when VALIDATE_EVENT_FORM action', () => {
+    it('should return validated event form state.', () => {
+      const validateEventForm = createAction(Actions.EventForm.validateEventParam)
+      const subject = EventFormReducer(eventFormInitialState, validateEventForm(testParams))
+
+      const nextState = eventFormInitialState.merge({
+        [testParams.id]: {
+          validationPassed: testParams.validationPassed,
+          errors: testParams.errors,
+        },
+      })
+
+      expect(subject).toEqual(nextState)
+    })
+  })
+})

--- a/reducers/eventForm.js
+++ b/reducers/eventForm.js
@@ -1,0 +1,29 @@
+// @flow
+import { handleActions } from 'redux-actions'
+import { Map, List } from 'immutable'
+
+import Actions from '../constants/Actions'
+
+export const eventFormInitialState = new Map({
+  name: new Map({
+    validationPassed: false,
+    errors: new List(),
+  }),
+  quota: new Map({
+    validationPassed: false,
+    errors: new List(),
+  }),
+})
+
+const validateEventForm = {
+  next: (state, action) => {
+    const { id, validationPassed, errors } = action.payload
+    return state.merge({ [id]: { validationPassed, errors } })
+  },
+}
+
+const eventFormReducerMap = {
+  [Actions.EventForm.validateEventParam]: validateEventForm,
+}
+
+export default handleActions(eventFormReducerMap, eventFormInitialState)

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
 import event from './event'
+import eventForm from './eventForm'
 import participant from './participant'
 
 export default combineReducers({
   event,
+  eventForm,
   participant,
 })

--- a/selectors/__tests__/EventFormSelector.spec.js
+++ b/selectors/__tests__/EventFormSelector.spec.js
@@ -1,0 +1,54 @@
+import { Map, List } from 'immutable'
+import * as EventFormSelector from '../eventForm'
+
+const nameErrorMessages = ['nameは必須です。']
+const quotaErrorMessages = []
+
+const testEventFormState = new Map({
+  name: new Map({
+    validationPassed: false,
+    errors: new List(nameErrorMessages),
+  }),
+  quota: new Map({
+    validationPassed: true,
+    errors: new List(quotaErrorMessages),
+  }),
+})
+const mockState = { eventForm: testEventFormState }
+
+describe('EventFormSelector', () => {
+  describe('getValidationErrorMessages', () => {
+    it('returns validation error messages from state.', () => {
+      const subject = EventFormSelector.getValidationErrorMessages(mockState)
+      expect(subject).toEqual({
+        name: nameErrorMessages,
+        quota: quotaErrorMessages,
+      })
+    })
+  })
+
+  describe('isValidationFailed', () => {
+    describe('when one of the filed validations failed', () => {
+      it('returns true.', () => {
+        const subject = EventFormSelector.isValidationFailed(mockState)
+        expect(subject).toEqual(true)
+      })
+    })
+
+    describe('when all of the field validations success', () => {
+      const successState = {
+        eventForm: testEventFormState.merge({
+          name: {
+            validationPassed: true,
+            errors: [],
+          },
+        }),
+      }
+
+      it('returns false.', () => {
+        const subject = EventFormSelector.isValidationFailed(successState)
+        expect(subject).toEqual(false)
+      })
+    })
+  })
+})

--- a/selectors/eventForm.js
+++ b/selectors/eventForm.js
@@ -1,0 +1,27 @@
+// @flow
+import { createSelector } from 'reselect'
+
+const getNameErrorList = (state: Object) => state.eventForm.getIn(['name', 'errors'])
+const getQuotaErrorList = (state: Object) => state.eventForm.getIn(['quota', 'errors'])
+
+const isNameValidationFailed = (state: Object) => (
+  !state.eventForm.getIn(['name', 'validationPassed'])
+)
+const isQuotaValidationFailed = (state: Object) => (
+  !state.eventForm.getIn(['quota', 'validationPassed'])
+)
+
+export const getValidationErrorMessages =
+  createSelector(
+    [getNameErrorList, getQuotaErrorList],
+    (nameErrorList, quotaErrorList) => ({
+      name: nameErrorList.toArray(),
+      quota: quotaErrorList.toArray(),
+    }),
+  )
+
+export const isValidationFailed =
+  createSelector(
+    [isNameValidationFailed, isQuotaValidationFailed],
+    (isNameFailed, isQuotaFailed) => isNameFailed || isQuotaFailed,
+  )

--- a/validators/BaseValidator.js
+++ b/validators/BaseValidator.js
@@ -1,0 +1,7 @@
+// @flow
+import Validator from 'validatorjs'
+
+Validator.useLang('ja')
+
+export default class BaseValidator extends Validator {
+}

--- a/validators/__tests__/eventFormValidator.spec.js
+++ b/validators/__tests__/eventFormValidator.spec.js
@@ -1,0 +1,44 @@
+import eventFormValidator from '../eventFormValidator'
+
+const id = 'name'
+const value = 'event1'
+
+const passedResult = {
+  id,
+  validationPassed: true,
+  errors: [],
+}
+
+const failedResult = {
+  id,
+  validationPassed: false,
+  errors: ['nameは必須です。'],
+}
+
+const excludedResult = {
+  ...passedResult,
+  id: 'description',
+}
+
+describe('EventFormValidator', () => {
+  describe('with valid params', () => {
+    const result = eventFormValidator(id, value)
+    it('returns passed result.', () => {
+      expect(result).toEqual(passedResult)
+    })
+  })
+
+  describe('with invalid params', () => {
+    const result = eventFormValidator(id, '')
+    it('returns failed result.', () => {
+      expect(result).toEqual(failedResult)
+    })
+  })
+
+  describe('with id excluded from validation', () => {
+    const result = eventFormValidator(excludedResult.id, '')
+    it('returns passed result.', () => {
+      expect(result).toEqual(excludedResult)
+    })
+  })
+})

--- a/validators/eventFormValidator.js
+++ b/validators/eventFormValidator.js
@@ -1,0 +1,16 @@
+// @flow
+import BaseValidator from './BaseValidator'
+
+const rules = {
+  name: 'required',
+  quota: 'required|numeric|min:1|max:1000',
+}
+
+export default (id: string, value: string) => {
+  const rule = rules[id]
+  if (rule) {
+    const validator = new BaseValidator({ [id]: value }, { [id]: rule })
+    return { id, validationPassed: validator.passes(), errors: validator.errors.get(id) }
+  }
+  return { id, validationPassed: true, errors: [] }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5950,6 +5950,10 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
+validatorjs@^3.14.2:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/validatorjs/-/validatorjs-3.14.2.tgz#b5407743fac0196528277c7ab0bd18e0fabcc3fb"
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
### Overview:概要
[validatorjs](https://github.com/skaterdav85/validatorjs) パッケージを導入して、フロントエンド側でのバリデーション機能を実装する。

### Technical changes:技術的変更点
- [validatorjs](https://github.com/skaterdav85/validatorjs) パッケージを追加
- `EventFormValidator` のチェック項目
  - `name`: 必須
  - `description`: チェックなし
  - `quota`: １以上１０００以下の数字
- エラーメッセージは各入力フィールドの右に表示（`TextInputField` コンポーネントの内部で表示）
- バリデーション用クラスである `Validator` クラスを以下の方針で使用
  - `validators` ディレクトリを作成し、`EventForm` など各フォーム用の Validator を個別に作成
  - エラーメッセージの言語設定を共通化するため `BaseValidator` クラスを作成し、各フォーム用Validator で呼び出す（ 現時点では日本語に設定。i18n 対応時は `BaseValidator` で言語を切り替える） 
- バリデーションのチェック状態およびエラーメッセージは redux で管理する

### Impact point:変更に関する影響箇所
フォーム送信時に入力項目に不備がある場合、フロントエンド側でエラーメッセージが表示され、送信ボタンが押せない。

### Change of UserInterface:UIの変更
- バリデーション失敗時：
![screenshot from 2018-02-23 09-41-25](https://user-images.githubusercontent.com/10824691/36572243-ec12ef14-187d-11e8-9d1f-67350de1ea5d.png)

- バリデーション成功時：
![screenshot from 2018-02-23 09-44-08](https://user-images.githubusercontent.com/10824691/36572277-1d4ba17a-187e-11e8-8a3e-63024f1ec50b.png)

### TODOS
- [x] validatorjs パッケージの追加
- [x] BaseValidatorクラス、各フォーム用Validator の作成
- [x] Action の作成
- [x] Reducer の作成
- [x] Selector の作成 
- [x] Page との接続
- [x] TextInputField Component でエラーメッセージを表示する
- [x] EventForm Component にAction を追加して入力項目のバリデーション機能を実装