### PR TITLE
Remove husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "jest:watch": "npm run jest -- --watch",
     "lint": "eslint . --cache",
     "flow": "flow",
-    "build": "next build && next export",
-    "precommit": "yarn lint && yarn flow"
+    "build": "next build && next export"
   },
   "dependencies": {
     "axios": "^0.16.2",
@@ -49,7 +48,6 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.0",
     "flow-bin": "^0.57.3",
-    "husky": "^0.14.3",
     "jest": "^21.2.1",
     "moxios": "^0.4.0",
     "react-test-renderer": "^16.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,14 +2965,6 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-husky@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
-
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -4272,10 +4264,6 @@ normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
-
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
@@ -5635,10 +5623,6 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
### Overview:概要
CIでFlowとLinter実行してるので、ローカルでコミット時に強制する必要はないかな
Now Flow and Linter are executed when pushing to the repo, so I think that husky is unnecessary.

### Technical changes:技術的変更点
- Remove [husky](https://github.com/typicode/husky)
