### PR TITLE
Enable direct access to Event pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "node": ">= 6.0"
   },
   "scripts": {
-    "start:prod": "next start",
-    "start": "next -p 4000",
+    "start:prod": "NODE_ENV=production node server.js",
+    "start": "NODE_ENV=development node server.js",
     "test": "npm run lint && npm run flow && npm run jest",
     "jest": "jest",
     "jest:watch": "npm run jest -- --watch",
@@ -22,6 +22,7 @@
     "lodash": "^4.17.4",
     "next": "^4.2.1",
     "normalizr": "^3.2.4",
+    "path-match": "^1.2.4",
     "path-to-regexp": "^2.1.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -4,9 +4,18 @@ import { Map, List } from 'immutable'
 
 import Actions from '../constants/Actions'
 
+const initialId = 0
+
 export const eventInitialState = new Map({
-  entityId: 0,
-  entities: new Map(),
+  entityId: initialId,
+  entities: new Map({
+    [initialId]: new Map({
+      name: null,
+      description: null,
+      quota: 0,
+      participants: new List([]),
+    }),
+  }),
   errors: new List(),
 })
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const { createServer } = require('http')
+const { parse } = require('url')
+const next = require('next')
+const pathMatch = require('path-match')
+
+const port = parseInt(process.env.PORT, 10) || 4000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+const route = pathMatch()
+const matchEventShow = route('/event/:id')
+
+app.prepare()
+  .then(() => {
+    createServer((req, res) => {
+      const { pathname, query } = parse(req.url, true)
+      const params = matchEventShow(pathname)
+      if (params === false) {
+        handle(req, res)
+        return
+      }
+      app.render(req, res, '/event/show', Object.assign(params, query))
+    })
+      .listen(port, (err) => {
+        if (err) throw err
+        // eslint-disable-next-line no-console
+        console.log(`> Ready on http://localhost:${port}`)
+      })
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,7 +4639,7 @@ path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-match@1.2.4:
+path-match@1.2.4, path-match@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/path-match/-/path-match-1.2.4.tgz#a62747f3c7e0c2514762697f24443585b09100ea"
   dependencies:


### PR DESCRIPTION
### Overview:概要
現在、イベントページに `/event/:id` のアドレスでアクセスすると、サーバに対応するルーティングがなく404 エラーとなる。このためフロントエンド側のサーバで `/event/:id` へのアクセスに対し、`/event/show?id=:id`の内容を返すよう設定を追加する。

### Technical changes:技術的変更点
- server.js でルーティングを定義した nextjs を立ち上げる
[Next.js](https://github.com/zeit/next.js/tree/canary/examples/parameterized-routing)のサンプルを参考に、独自のルーティングを実装するフロントエンドのサーバをserver.js に定義する。

- `path-match` パッケージの導入
クライアントのリクエストURL から`:id`に該当する箇所を抜き出すため、`path-match` パッケージを使用する。

- Event reducer のinitialState の修正
これまではイベント作成ページから遷移してイベント詳細ページが表示されることが想定されていた。
イベントページに直接アクセスする場合、 現状の`new Map()` のみのinitialState では Selector の処理でエラーが発生するため、必要なプロパティを持つよう変更する。

なお、今回の方式ではイベントのデータは従来通りクライアント側からバックエンドサーバへ `componentDidMount` 内で fetch し、SSRは行わない。

### How to check this PR:動作確認
イベント作成ページで新規にイベントを作成する(イベントID を確認しておく)。
ブラウザの別のタブから`localhost:4000/event/:id`に直接アクセスすることで、イベント詳細ページが表示されるようになる。

### Change of UserInterface:UIの変更
変更なし
