### PR TITLE
Remove participant name form

### DIFF
--- a/actions/__tests__/EventAction.spec.js
+++ b/actions/__tests__/EventAction.spec.js
@@ -168,19 +168,20 @@ describe('EventAction', () => {
   })
 
   describe('cancelRegistration', () => {
-    const cancelTestParams = { id: 1, eventId: 1 }
+    const cancelTestParams = { id: 1 }
     describe('when successes to cancel Registraion', () => {
       beforeEach(() => {
         // eslint-disable-next-line no-underscore-dangle
         mockAPI.__setMockResult(true)
       })
       it('returns cancel regstration action with participant data.', () => {
-        expect.assertions(2)
-        return store.dispatch(Actions.registerForEvent(cancelTestParams))
+        expect.assertions(3)
+        return store.dispatch(Actions.cancelRegistration(cancelTestParams))
           .then(() => {
             const action = store.getActions()[0]
-            expect(action.type).toBe(ActionsType.Event.registerForEvent)
+            expect(action.type).toBe(ActionsType.Event.cancelRegistration)
             expect(action.payload).toEqual(cancelTestParams)
+            expect(action.meta.normalizr.schema).toEqual(EventSchema)
           })
       })
     })
@@ -192,10 +193,10 @@ describe('EventAction', () => {
       })
       it('returns join action with instance of Error.', () => {
         expect.assertions(2)
-        return store.dispatch(Actions.registerForEvent(cancelTestParams))
+        return store.dispatch(Actions.cancelRegistration(cancelTestParams))
           .then(() => {
             const action = store.getActions()[0]
-            expect(action.type).toBe(ActionsType.Event.registerForEvent)
+            expect(action.type).toBe(ActionsType.Event.cancelRegistration)
             expect(action.payload).toBeInstanceOf(Error)
           })
       })

--- a/actions/event.js
+++ b/actions/event.js
@@ -38,7 +38,9 @@ export const registerForEvent =
     metaCreator(ParticipantSchema),
   )
 
-export const cancelRegistration = createAction(
-  ActionsType.Event.cancelRegistration,
-  participant.delete,
-)
+export const cancelRegistration =
+  createAction(
+    ActionsType.Event.cancelRegistration,
+    event.cancelRegistration,
+    metaCreator(EventSchema),
+  )

--- a/api/Event.js
+++ b/api/Event.js
@@ -1,5 +1,10 @@
 // @flow
+import pathToRegexp from 'path-to-regexp'
 import Base from './Base'
 
 export default class Event extends Base {
+  cancelRegistration = (params: number) => {
+    const url = pathToRegexp.compile(this.endpoints.cancelRegistration)(params)
+    return this.client.delete(url).then(this.onSuccess, this.onFailure)
+  }
 }

--- a/api/__mocks__/index.js
+++ b/api/__mocks__/index.js
@@ -13,6 +13,7 @@ const mockedPromise = params => (
 export const event = {
   create: mockedPromise,
   find: mockedPromise,
+  cancelRegistration: mockedPromise,
 }
 
 export const participant = {

--- a/api/__tests__/Event.spec.js
+++ b/api/__tests__/Event.spec.js
@@ -1,0 +1,48 @@
+import moxios from 'moxios'
+import client from '../client'
+import Event from '../Event'
+import * as endpoints from '../../constants/endpoints'
+import eventParams from '../../factories/Event'
+import '../../env-config'
+
+const event = new Event(endpoints.event)
+
+// Removing extra '/' from endpoint
+const baseUrl = process.env.BASE_URL + endpoints.event.all.substring(1)
+const cancelUrl = `${baseUrl}/1/registrations`
+
+const { event1 } = eventParams
+
+jest.mock('../../utils/auth')
+
+describe('Event', () => {
+  beforeEach(() => {
+    expect.assertions(1)
+    moxios.install(client)
+  })
+
+  afterEach(() => {
+    moxios.uninstall()
+  })
+
+  describe('.cancelRegistration', () => {
+    describe('on success', () => {
+      it('should return canceled mock data.', () => {
+        expect.assertions(1)
+        moxios.stubOnce('delete', cancelUrl, { status: 200, response: event1 })
+        return event.cancelRegistration(event1).then((res) => {
+          expect(res).toEqual(event1)
+        })
+      })
+    })
+    describe('on failure', () => {
+      it('should return Error object with messages.', () => {
+        expect.assertions(1)
+        moxios.stubOnce('delete', cancelUrl, { status: 404 })
+        return event.cancelRegistration(event1).catch((err) => {
+          expect(err.errors).toEqual(['Not Found'])
+        })
+      })
+    })
+  })
+})

--- a/components/Participant/__tests__/Participant.spec.js
+++ b/components/Participant/__tests__/Participant.spec.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
 import Participant from '../index'
 
@@ -13,7 +13,7 @@ const testProps = {
 describe('Participant', () => {
   describe('with admitted participant', () => {
     it('renders participant component with admitted message.', () => {
-      const wrapper = shallow(<Participant {...testProps} onCancel={jest.fn()} />)
+      const wrapper = shallow(<Participant {...testProps} />)
       const tree = shallowToJson(wrapper)
 
       expect(tree).toMatchSnapshot()
@@ -22,28 +22,11 @@ describe('Participant', () => {
 
   describe('with waitlisted participant', () => {
     it('renders participant component with waitlisted message.', () => {
-      const wrapper = shallow(<Participant {...testProps} onWaitingList onCancel={jest.fn()} />)
+      const waitlistedProps = { ...testProps, onWaitingList: true }
+      const wrapper = shallow(<Participant {...waitlistedProps} />)
       const tree = shallowToJson(wrapper)
 
       expect(tree).toMatchSnapshot()
-    })
-  })
-
-  describe('when clicked', () => {
-    const onCancel = jest.fn()
-    const wrapper = mount(<Participant {...testProps} onCancel={onCancel} />)
-
-    wrapper.find('button').simulate('click')
-
-    it('should call onCancel once.', () => {
-      expect(onCancel).toHaveBeenCalledTimes(1)
-    })
-
-    it('should call onCancel with correct argument.', () => {
-      expect(onCancel).toBeCalledWith({
-        id: testProps.id,
-        eventId: testProps.eventId,
-      })
     })
   })
 })

--- a/components/Participant/__tests__/__snapshots__/Participant.spec.js.snap
+++ b/components/Participant/__tests__/__snapshots__/Participant.spec.js.snap
@@ -11,20 +11,9 @@ exports[`Participant with admitted participant renders participant component wit
   >
     Participant 1
   </span>
-  <span
-    style={
-      Object {
-        "marginRight": 10,
-      }
-    }
-  >
+  <span>
     参加可能
   </span>
-  <button
-    onClick={[Function]}
-  >
-    キャンセル
-  </button>
 </div>
 `;
 
@@ -39,19 +28,8 @@ exports[`Participant with waitlisted participant renders participant component w
   >
     Participant 1
   </span>
-  <span
-    style={
-      Object {
-        "marginRight": 10,
-      }
-    }
-  >
+  <span>
     キャンセル待ち
   </span>
-  <button
-    onClick={[Function]}
-  >
-    キャンセル
-  </button>
 </div>
 `;

--- a/components/Participant/index.js
+++ b/components/Participant/index.js
@@ -1,38 +1,18 @@
 // @flow
-import React, { Component } from 'react'
+import React from 'react'
 
 type Props = {
-  id: number,
-  eventId: number,
   name: string,
   onWaitingList: boolean,
-  onCancel: Function,
 }
 
-export default class Participant extends Component<Props> {
-  onCancelHandler = () => {
-    this.props.onCancel({
-      id: this.props.id,
-      eventId: this.props.eventId,
-    })
-  }
-
-  render() {
-    const margin = { marginRight: 10 }
-    return (
-      <div>
-        <span style={margin}>
-          { this.props.name }
-        </span>
-        <span style={margin}>
-          { this.props.onWaitingList ?
-            'キャンセル待ち' : '参加可能'
-          }
-        </span>
-        <button onClick={this.onCancelHandler} >
-          キャンセル
-        </button>
-      </div>
-    )
-  }
-}
+export default (props: Props) => (
+  <div>
+    <span style={{ marginRight: 10 }}>
+      { props.name }
+    </span>
+    <span>
+      { props.onWaitingList ? 'キャンセル待ち' : '参加可能' }
+    </span>
+  </div>
+)

--- a/components/Participant/index.js
+++ b/components/Participant/index.js
@@ -6,7 +6,7 @@ type Props = {
   onWaitingList: boolean,
 }
 
-export default (props: Props) => (
+const Participant = (props: Props) => (
   <div>
     <span style={{ marginRight: 10 }}>
       { props.name }
@@ -16,3 +16,5 @@ export default (props: Props) => (
     </span>
   </div>
 )
+
+export default Participant

--- a/components/ParticipantForm/__tests__/ParticipantForm.spec.js
+++ b/components/ParticipantForm/__tests__/ParticipantForm.spec.js
@@ -3,10 +3,6 @@ import { mount, shallow } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
 import ParticipantForm from '../index'
 
-const inputValues = {
-  name: 'participant1',
-}
-
 const testProps = {
   eventId: 1,
   participateButtonText: '参加登録',
@@ -52,20 +48,14 @@ describe('ParticipantForm', () => {
       const onSubmit = jest.fn()
       const wrapper = mount(<ParticipantForm {...testProps} onSubmit={onSubmit} />)
 
-      const nameElement = wrapper.find('[type="text"]')
-
-      nameElement.simulate(
-        'change',
-        { target: { id: 'name', value: inputValues.name } },
-      )
-      wrapper.find('[type="submit"]').simulate('submit')
+      wrapper.find('[type="button"]').simulate('click')
 
       it('should call onSubmit once.', () => {
         expect(onSubmit).toHaveBeenCalledTimes(1)
       })
 
       it('should call onSubmit with correct argument.', () => {
-        expect(onSubmit).toBeCalledWith({ ...inputValues, eventId: testProps.eventId })
+        expect(onSubmit).toBeCalledWith({ eventId: testProps.eventId })
       })
     })
   })

--- a/components/ParticipantForm/__tests__/ParticipantForm.spec.js
+++ b/components/ParticipantForm/__tests__/ParticipantForm.spec.js
@@ -1,62 +1,51 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
 import ParticipantForm from '../index'
 
 const testProps = {
   eventId: 1,
-  participateButtonText: '参加登録',
+  hasEventWaitlist: true,
+  isUserRegistered: false,
   message: null,
+  onSubmit: () => {},
+  onCancel: () => {},
 }
 
 const completeProps = {
-  eventId: 1,
-  participateButtonText: '参加登録',
+  ...testProps,
   message: '参加登録が完了しました。',
 }
 
-const errorProps = {
-  ...testProps,
-  errors: ['名前を入力して下さい'],
-  message: null,
-}
-
 describe('ParticipantForm', () => {
-  it('renders participant form component', () => {
-    const wrapper = shallow(<ParticipantForm {...testProps} onSubmit={jest.fn()} />)
-    const tree = shallowToJson(wrapper)
+  describe('renders participant form component', () => {
+    describe('when user has already registered for the event', () => {
+      it('renders CancelRegistrationButton component.', () => {
+        const wrapper =
+          shallow(<ParticipantForm {...testProps} isUserRegistered />)
+        const tree = shallowToJson(wrapper)
 
-    expect(tree).toMatchSnapshot()
-  })
-
-  it('renders participant form component with completion message', () => {
-    const wrapper = shallow(<ParticipantForm {...completeProps} onSubmit={jest.fn()} />)
-    const tree = shallowToJson(wrapper)
-
-    expect(tree).toMatchSnapshot()
-  })
-
-  it('renders participant form component with error message', () => {
-    const wrapper = shallow(<ParticipantForm {...errorProps} onSubmit={jest.fn()} />)
-    const tree = shallowToJson(wrapper)
-
-    expect(tree).toMatchSnapshot()
-  })
-
-  describe('when submit', () => {
-    describe('with correct argument', () => {
-      const onSubmit = jest.fn()
-      const wrapper = mount(<ParticipantForm {...testProps} onSubmit={onSubmit} />)
-
-      wrapper.find('[type="button"]').simulate('click')
-
-      it('should call onSubmit once.', () => {
-        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(tree).toMatchSnapshot()
       })
+    })
 
-      it('should call onSubmit with correct argument.', () => {
-        expect(onSubmit).toBeCalledWith({ eventId: testProps.eventId })
+    describe('when user has NOT registered for the event yet', () => {
+      it('renders ParticipantButton component.', () => {
+        const wrapper =
+          shallow(<ParticipantForm {...testProps} />)
+        const tree = shallowToJson(wrapper)
+
+        expect(tree).toMatchSnapshot()
       })
+    })
+  })
+
+  describe('on completing registeration for event', () => {
+    it('renders completion message', () => {
+      const wrapper = shallow(<ParticipantForm {...completeProps} />)
+      const tree = shallowToJson(wrapper)
+
+      expect(tree).toMatchSnapshot()
     })
   })
 })

--- a/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
@@ -1,44 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ParticipantForm renders participant form component 1`] = `
-<div>
-  <p>
-     
-     
-  </p>
-  <input
-    onClick={[Function]}
-    type="button"
-    value="このイベントに参加する"
-  />
-</div>
-`;
-
-exports[`ParticipantForm renders participant form component with completion message 1`] = `
+exports[`ParticipantForm on completing registeration for event renders completion message 1`] = `
 <div>
   <p>
      
     参加登録が完了しました。
      
   </p>
-  <input
+  <ParticipantButton
+    eventId={1}
+    hasEventWaitlist={true}
     onClick={[Function]}
-    type="button"
-    value="このイベントに参加する"
   />
 </div>
 `;
 
-exports[`ParticipantForm renders participant form component with error message 1`] = `
+exports[`ParticipantForm renders participant form component when user has NOT registered for the event yet renders ParticipantButton component. 1`] = `
 <div>
   <p>
      
      
   </p>
-  <input
+  <ParticipantButton
+    eventId={1}
+    hasEventWaitlist={true}
     onClick={[Function]}
-    type="button"
-    value="このイベントに参加する"
+  />
+</div>
+`;
+
+exports[`ParticipantForm renders participant form component when user has already registered for the event renders CancelRegistrationButton component. 1`] = `
+<div>
+  <p>
+     
+     
+  </p>
+  <CancelRegistrationButton
+    eventId={1}
+    onClick={[Function]}
   />
 </div>
 `;

--- a/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
@@ -2,66 +2,43 @@
 
 exports[`ParticipantForm renders participant form component 1`] = `
 <div>
-  <h3>
-    Event participation form
-  </h3>
-  <form
-    onSubmit={[Function]}
-  >
-    <Component
-      errorMessages={Array []}
-      id="name"
-      onBlur={[Function]}
-      onChange={[Function]}
-      value=""
-    />
-    <ParticipantButton />
-  </form>
+  <p>
+     
+     
+  </p>
+  <input
+    onClick={[Function]}
+    type="button"
+    value="このイベントに参加する"
+  />
 </div>
 `;
 
 exports[`ParticipantForm renders participant form component with completion message 1`] = `
 <div>
-  <h3>
-    Event participation form
-  </h3>
-  参加登録が完了しました。
-  <form
-    onSubmit={[Function]}
-  >
-    <Component
-      errorMessages={Array []}
-      id="name"
-      onBlur={[Function]}
-      onChange={[Function]}
-      value=""
-    />
-    <ParticipantButton />
-  </form>
+  <p>
+     
+    参加登録が完了しました。
+     
+  </p>
+  <input
+    onClick={[Function]}
+    type="button"
+    value="このイベントに参加する"
+  />
 </div>
 `;
 
 exports[`ParticipantForm renders participant form component with error message 1`] = `
 <div>
-  <h3>
-    Event participation form
-  </h3>
-  <ul>
-    <li>
-      名前を入力して下さい
-    </li>
-  </ul>
-  <form
-    onSubmit={[Function]}
-  >
-    <Component
-      errorMessages={Array []}
-      id="name"
-      onBlur={[Function]}
-      onChange={[Function]}
-      value=""
-    />
-    <ParticipantButton />
-  </form>
+  <p>
+     
+     
+  </p>
+  <input
+    onClick={[Function]}
+    type="button"
+    value="このイベントに参加する"
+  />
 </div>
 `;

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -1,27 +1,38 @@
 // @flow
 import React from 'react'
+import ParticipantButton from '../buttons/ParticipantButton'
+import CancelRegistrationButton from '../buttons/CancelRegistrationButton'
 
 type Props = {
   eventId: ?number,
   hasEventWaitlist: boolean,
+  isUserRegistered: boolean,
   message: string,
   onSubmit: Function,
+  onCancel: Function,
 }
 
-export default (props: Props) => {
-  const onClickHandler = (e: SyntheticEvent<>) => {
-    e.preventDefault()
-    props.onSubmit({ eventId: props.eventId })
-  }
+const ParticipantForm = (props: Props) => {
+  const {
+    eventId, onSubmit, onCancel, hasEventWaitlist,
+  } = props
 
   return (
     <div>
       <p> { props.message } </p>
-      <input
-        type="button"
-        value={props.hasEventWaitlist ? 'キャンセル待ちに登録' : 'このイベントに参加する'}
-        onClick={onClickHandler}
-      />
+      { props.isUserRegistered ?
+        <CancelRegistrationButton
+          eventId={eventId}
+          onClick={onCancel}
+        /> :
+        <ParticipantButton
+          eventId={eventId}
+          hasEventWaitlist={hasEventWaitlist}
+          onClick={onSubmit}
+        />
+      }
     </div>
   )
 }
+
+export default ParticipantForm

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -1,63 +1,27 @@
 // @flow
-import React, { Component } from 'react'
-import ParticipantButton from '../buttons/ParticipantButton'
-import TextInputField from '../forms/TextInputField'
+import React from 'react'
 
 type Props = {
-  onSubmit: Function,
+  eventId: ?number,
   hasEventWaitlist: boolean,
-  eventId: ?number,
-  errors: ?string[],
   message: string,
-}
-type State = {
-  name: string,
-  eventId: ?number,
+  onSubmit: Function,
 }
 
-export default class ParticipantForm extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      name: '',
-      eventId: props.eventId,
-    }
-  }
-
-  onChangeHandler = (e: SyntheticInputEvent<>) => {
-    this.setState({
-      ...this.state,
-      [e.target.id]: e.target.value,
-    })
-  }
-
-  onSubmitHandler = (e: SyntheticEvent<>) => {
+export default (props: Props) => {
+  const onClickHandler = (e: SyntheticEvent<>) => {
     e.preventDefault()
-    this.props.onSubmit(this.state)
+    props.onSubmit({ eventId: props.eventId })
   }
 
-  render() {
-    return (
-      <div>
-        <h3>Event participation form</h3>
-        { this.props.errors &&
-          <ul>
-            { this.props.errors.map(error =>
-              <li>{ error }</li>)}
-          </ul>
-        }
-        { this.props.message }
-        <form onSubmit={this.onSubmitHandler}>
-          <TextInputField
-            id="name"
-            value={this.state.name}
-            onChange={this.onChangeHandler}
-            onBlur={() => {}}
-            errorMessages={[]}
-          />
-          <ParticipantButton hasEventWaitlist={this.props.hasEventWaitlist} />
-        </form>
-      </div>
-    )
-  }
+  return (
+    <div>
+      <p> { props.message } </p>
+      <input
+        type="button"
+        value={props.hasEventWaitlist ? 'キャンセル待ちに登録' : 'このイベントに参加する'}
+        onClick={onClickHandler}
+      />
+    </div>
+  )
 }

--- a/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
+++ b/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
@@ -6,7 +6,7 @@ exports[`ParticipantList Component renders self. 1`] = `
     <li
       key="1"
     >
-      <Component
+      <Participant
         eventId={1}
         id={1}
         name="participant1"
@@ -15,7 +15,7 @@ exports[`ParticipantList Component renders self. 1`] = `
     <li
       key="2"
     >
-      <Component
+      <Participant
         eventId={1}
         id={2}
         name="participant2"

--- a/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
+++ b/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
@@ -6,7 +6,7 @@ exports[`ParticipantList Component renders self. 1`] = `
     <li
       key="1"
     >
-      <Participant
+      <Component
         eventId={1}
         id={1}
         name="participant1"
@@ -15,7 +15,7 @@ exports[`ParticipantList Component renders self. 1`] = `
     <li
       key="2"
     >
-      <Participant
+      <Component
         eventId={1}
         id={2}
         name="participant2"

--- a/components/ParticipantsList/index.js
+++ b/components/ParticipantsList/index.js
@@ -4,7 +4,6 @@ import ParticipantComponent from '../Participant'
 
 type Props = {
   participants: ?Object[],
-  onCancel: Function,
 }
 
 const ParticipantsList = (props: Props) => (
@@ -13,7 +12,7 @@ const ParticipantsList = (props: Props) => (
       <ul>
         { props.participants.map(participant => (
           <li key={participant.id}>
-            <ParticipantComponent {...participant} onCancel={props.onCancel} />
+            <ParticipantComponent {...participant} />
           </li>
         ))}
       </ul>

--- a/components/buttons/CancelRegistrationButton/__tests__/CancelRegistrationButton.spec.js
+++ b/components/buttons/CancelRegistrationButton/__tests__/CancelRegistrationButton.spec.js
@@ -30,7 +30,7 @@ describe('CancelRegistrationButton', () => {
 
     it('should call onCancel with correct argument.', () => {
       expect(onCancel).toBeCalledWith({
-        eventId: testProps.eventId,
+        id: testProps.eventId,
       })
     })
   })

--- a/components/buttons/CancelRegistrationButton/__tests__/CancelRegistrationButton.spec.js
+++ b/components/buttons/CancelRegistrationButton/__tests__/CancelRegistrationButton.spec.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import shallowToJson from 'enzyme-to-json'
+import CancelRegistrationButton from '../index'
+
+const testProps = {
+  eventId: 1,
+}
+
+describe('CancelRegistrationButton', () => {
+  describe('with event has a waitlist', () => {
+    it('renders CancelRegistrationButton.', () => {
+      const wrapper = shallow(<CancelRegistrationButton />)
+      const tree = shallowToJson(wrapper)
+
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
+  describe('when clicked', () => {
+    const onCancel = jest.fn()
+    const wrapper =
+      mount(<CancelRegistrationButton {...testProps} onClick={onCancel} />)
+
+    wrapper.find('button').simulate('click')
+
+    it('should call onCancel once.', () => {
+      expect(onCancel).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onCancel with correct argument.', () => {
+      expect(onCancel).toBeCalledWith({
+        eventId: testProps.eventId,
+      })
+    })
+  })
+})

--- a/components/buttons/CancelRegistrationButton/__tests__/__snapshots__/CancelRegistrationButton.spec.js.snap
+++ b/components/buttons/CancelRegistrationButton/__tests__/__snapshots__/CancelRegistrationButton.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CancelRegistrationButton with event has a waitlist renders CancelRegistrationButton. 1`] = `
+<button
+  onClick={[Function]}
+>
+  登録をキャンセルする
+</button>
+`;

--- a/components/buttons/CancelRegistrationButton/index.js
+++ b/components/buttons/CancelRegistrationButton/index.js
@@ -6,10 +6,10 @@ type Props = {
   onClick: Function,
 }
 
-export default (props: Props) => {
+const CancelRegistrationButton = (props: Props) => {
   const onClickHandler = (e: SyntheticEvent<>) => {
     e.preventDefault()
-    props.onClick({ eventId: props.eventId })
+    props.onClick({ id: props.eventId })
   }
 
   return (
@@ -18,3 +18,5 @@ export default (props: Props) => {
     </button>
   )
 }
+
+export default CancelRegistrationButton

--- a/components/buttons/CancelRegistrationButton/index.js
+++ b/components/buttons/CancelRegistrationButton/index.js
@@ -1,0 +1,20 @@
+// @flow
+import React from 'react'
+
+type Props = {
+  eventId: ?number,
+  onClick: Function,
+}
+
+export default (props: Props) => {
+  const onClickHandler = (e: SyntheticEvent<>) => {
+    e.preventDefault()
+    props.onClick({ eventId: props.eventId })
+  }
+
+  return (
+    <button onClick={onClickHandler}>
+      登録をキャンセルする
+    </button>
+  )
+}

--- a/components/buttons/ParticipantButton/__tests__/__snapshots__/ParticipantButton.spec.js.snap
+++ b/components/buttons/ParticipantButton/__tests__/__snapshots__/ParticipantButton.spec.js.snap
@@ -1,15 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ParticipantButton with event has a waitlist renders participant button with waitlited message. 1`] = `
-<input
-  type="submit"
-  value="キャンセル待ちに登録"
-/>
+<button
+  onClick={[Function]}
+>
+  キャンセル待ちに登録
+</button>
 `;
 
 exports[`ParticipantButton with event has no waitlist renders participant button with admit message. 1`] = `
-<input
-  type="submit"
-  value="参加登録"
-/>
+<button
+  onClick={[Function]}
+>
+  参加登録
+</button>
 `;

--- a/components/buttons/ParticipantButton/index.js
+++ b/components/buttons/ParticipantButton/index.js
@@ -2,14 +2,22 @@
 import React from 'react'
 
 type Props = {
+  eventId: ?number,
   hasEventWaitlist: boolean,
+  onClick: Function,
 }
 
-const ParticipantButton = (props: Props) => (
-  <input
-    type="submit"
-    value={props.hasEventWaitlist ? 'キャンセル待ちに登録' : '参加登録'}
-  />
-)
+const ParticipantButton = (props: Props) => {
+  const onClickHandler = (e: SyntheticEvent<>) => {
+    e.preventDefault()
+    props.onClick({ eventId: props.eventId })
+  }
+
+  return (
+    <button onClick={onClickHandler}>
+      {props.hasEventWaitlist ? 'キャンセル待ちに登録' : '参加登録'}
+    </button>
+  )
+}
 
 export default ParticipantButton

--- a/constants/endpoints.js
+++ b/constants/endpoints.js
@@ -4,6 +4,7 @@ export const event = {
   create: '/events',
   update: '/events/:id',
   delete: '/events/:id',
+  cancelRegistration: '/events/:id/registrations',
 }
 
 export const participant = {

--- a/containers/EventView.js
+++ b/containers/EventView.js
@@ -45,13 +45,14 @@ class EventView extends React.Component<Props> {
           <EventComponent event={event} />
           <ParticipantFormComponent
             eventId={event.id}
+            isUserRegistered={event.registered}
             hasEventWaitlist={this.props.hasWaitlist}
             message={this.props.participantMessage}
             onSubmit={this.props.registerForEvent}
+            onCancel={this.props.cancelRegistration}
           />
           <ParticipantsListComponent
             participants={this.props.participants}
-            onCancel={this.props.cancelRegistration}
           />
         </div>
     )

--- a/containers/EventView.js
+++ b/containers/EventView.js
@@ -7,7 +7,6 @@ import { fetchEvent, registerForEvent, cancelRegistration } from '../actions/eve
 import { getCurrentEvent, getHasWaitlist, getHasNotFoundError } from '../selectors/event'
 import {
   getParticipants,
-  getParticipantErrorsArray,
   getParticipantMessage,
 } from '../selectors/participant'
 
@@ -22,7 +21,6 @@ type Props = {
   hasNotFoundError: boolean,
   hasWaitlist: boolean,
   participants: ?Object[],
-  participantErrors: ?string[],
   participantMessage: string,
   fetchEvent: Function,
   registerForEvent: Function,
@@ -47,7 +45,6 @@ class EventView extends React.Component<Props> {
           <EventComponent event={event} />
           <ParticipantFormComponent
             eventId={event.id}
-            errors={this.props.participantErrors}
             hasEventWaitlist={this.props.hasWaitlist}
             message={this.props.participantMessage}
             onSubmit={this.props.registerForEvent}
@@ -66,7 +63,6 @@ const mapStateToProps = state => ({
   hasNotFoundError: getHasNotFoundError(state),
   hasWaitlist: getHasWaitlist(state),
   participants: getParticipants(state),
-  participantErrors: getParticipantErrorsArray(state),
   participantMessage: getParticipantMessage(state),
 })
 

--- a/factories/Event.js
+++ b/factories/Event.js
@@ -4,6 +4,7 @@ export default {
     name: 'event1',
     description: 'This is the first event.',
     quota: 10,
+    registered: true,
     participants: [],
   },
   errorEvent: {
@@ -11,6 +12,7 @@ export default {
     name: 'event1',
     description: 'This is the first event.',
     quota: 10,
+    registered: false,
     participants: [],
     errors: ['nameを入力してください', 'nameは１０文字以内です'],
   },

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -108,7 +108,7 @@ describe('Event Reducer', () => {
 
     describe('with success cancel registration', () => {
       it('should delete registered participant', () => {
-        const subject = EventReducer(prevState, cancelRegistration(participant1))
+        const subject = EventReducer(prevState, cancelRegistration(normalizedEvent))
         expect(subject).toEqual(nextState)
       })
     })
@@ -116,7 +116,7 @@ describe('Event Reducer', () => {
     describe('with failure cancel registration', () => {
       it('should keep previous state', () => {
         const subject = EventReducer(prevState, cancelRegistration(new ApiResponseError(error)))
-        expect(subject).toEqual(prevState)
+        expect(subject.get('errors')).toEqual(errorMessages)
       })
     })
   })

--- a/reducers/__tests__/ParticipantReducer.spec.js
+++ b/reducers/__tests__/ParticipantReducer.spec.js
@@ -106,17 +106,15 @@ describe('Participant Reducer', () => {
     const cancelRegistration = createAction(Actions.Event.cancelRegistration)
 
     describe('with success cancel registration', () => {
-      it('should delete registered participant', () => {
-        const participantParams = ConvertCase.snakeKeysOf(waitlistedParticipant)
-        const prevState =
-          participantMergedState.mergeDeep({ entities: waitlistedParticipantEntity })
-        const subject = ParticipantReducer(
-          prevState,
-          cancelRegistration(participantParams),
-        )
-        const nextState = participantMergedState
+      it('should return participants in canceled event', () => {
+        const eventParams = {
+          ...EventParams.event1,
+          participants: [ConvertCase.snakeKeysOf(admittedParticipant)],
+        }
+        const normalizedEvent = normalize(eventParams, EventSchema)
+        const subject = ParticipantReducer(initialState, cancelRegistration(normalizedEvent))
 
-        expect(subject).toEqual(nextState)
+        expect(subject).toEqual(participantMergedState)
       })
     })
 

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -13,6 +13,7 @@ export const eventInitialState = new Map({
       name: null,
       description: null,
       quota: 0,
+      registered: false,
       participants: new List([]),
     }),
   }),
@@ -42,23 +43,11 @@ const mergeParticipant = {
   },
 }
 
-const deleteParticipant = {
-  next: (state, action) => {
-    const eventId = state.get('entityId').toString()
-    const participantId = action.payload.id
-
-    return state.updateIn(
-      ['entities', eventId, 'participants'],
-      participants => participants.filter(id => id !== participantId),
-    )
-  },
-}
-
 const eventReducerMap = {
   [Actions.Event.createEvent]: setEvent,
   [Actions.Event.fetchEvent]: setEvent,
   [Actions.Event.registerForEvent]: mergeParticipant,
-  [Actions.Event.cancelRegistration]: deleteParticipant,
+  [Actions.Event.cancelRegistration]: setEvent,
 }
 
 export default handleActions(eventReducerMap, eventInitialState)

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -48,7 +48,7 @@ const participantReducerMap = {
   [Actions.Event.cancelRegistration]: {
     next: (state, action) => (
       state.merge({
-        entities: state.get('entities').delete(action.payload.id.toString()),
+        entities: toCamelCase(action.payload.entities.participant),
         errors: [],
       })
     ),

--- a/types/Event.js
+++ b/types/Event.js
@@ -9,6 +9,7 @@ export type EventProps = {
   name: string,
   description: string,
   quota: number,
+  registered: boolean,
   participants: Object[],
   errors: ?string[]
 }


### PR DESCRIPTION
### Overview:概要
ユーザー認証機能の実装に伴い、イベントの参加登録時に名前を入力する必要が無くなった。
そこで、参加者名のフォームを削除し、以下のボタンを表示する。

- イベントに参加登録して**いない**場合：  `参加登録／キャンセル待ちに登録` ボタンを表示
- イベントに参加登録を**申し込み済**の場合：  `登録をキャンセルする` ボタンを表示

### Technical changes:技術的変更点
- ParticipantForm コンポーネントからフォームを削除、ローカル state が必要なくなるので、関数型コンポーネントとする
- イベントの参加登録をキャンセルするボタン、 ParticipantCancelButton コンポーネントを追加する
- ユーザーが参加済みかどうかを判定する処理を Event selector に追加、Event Container で判定結果によって参加ボタン／キャンセルボタンの表示を切り替える

### Impact point:変更に関する影響箇所
現状では、ユーザが１つのイベントに複数回、参加登録できるが、本PR の merge 後は参加登録は１回だけ可能となる。(キャンセルすれば再び登録できるようになる)
なお、バックエンド側では複数回登録のバリデーションは行っていないので、別途修正が必要です。

### Change of UserInterface:UIの変更
後ほど追加予定

### Todo
- [x] 参加者名フォームの削除
- [x] 参加キャンセルボタンの実装
- [x] Event APIに参加キャンセル用メソッドを追加
- [x] Event Action の参加キャンセルアクションで上記メソッドを使用するよう変更
- [x] Event および Participant Reducer で参加キャンセルアクションへの処理を変更
- [x] イベントに参加登録済みかの判定処理、 参加ボタン／キャンセルボタンの切替処理の追加