### PR TITLE
Hide event registration button for not sign-in users

### DIFF
--- a/components/Auth/index.js
+++ b/components/Auth/index.js
@@ -54,7 +54,7 @@ const withAuth = (Component: ComponentType<*>) =>
           { this.state.isLoading ? (
             <Loading />
           ) : (
-            <Component {...this.state} session={this.state.session} />
+            <Component {...this.props} {...this.state} session={this.state.session} />
           )}
         </div>
       )

--- a/components/ParticipantForm/__tests__/ParticipantForm.spec.js
+++ b/components/ParticipantForm/__tests__/ParticipantForm.spec.js
@@ -6,6 +6,7 @@ import ParticipantForm from '../index'
 const testProps = {
   eventId: 1,
   hasEventWaitlist: true,
+  isSignedIn: true,
   isUserRegistered: false,
   message: null,
   onSubmit: () => {},
@@ -33,6 +34,16 @@ describe('ParticipantForm', () => {
       it('renders ParticipantButton component.', () => {
         const wrapper =
           shallow(<ParticipantForm {...testProps} />)
+        const tree = shallowToJson(wrapper)
+
+        expect(tree).toMatchSnapshot()
+      })
+    })
+
+    describe('when user NOT signed in', () => {
+      it('renders nothig.', () => {
+        const wrapper =
+          shallow(<ParticipantForm {...testProps} isSignedIn={false} />)
         const tree = shallowToJson(wrapper)
 
         expect(tree).toMatchSnapshot()

--- a/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
@@ -2,42 +2,50 @@
 
 exports[`ParticipantForm on completing registeration for event renders completion message 1`] = `
 <div>
-  <p>
-     
-    参加登録が完了しました。
-     
-  </p>
-  <ParticipantButton
-    eventId={1}
-    hasEventWaitlist={true}
-    onClick={[Function]}
-  />
+  <div>
+    <p>
+       
+      参加登録が完了しました。
+       
+    </p>
+    <ParticipantButton
+      eventId={1}
+      hasEventWaitlist={true}
+      onClick={[Function]}
+    />
+  </div>
 </div>
 `;
 
+exports[`ParticipantForm renders participant form component when user NOT signed in renders nothig. 1`] = `<div />`;
+
 exports[`ParticipantForm renders participant form component when user has NOT registered for the event yet renders ParticipantButton component. 1`] = `
 <div>
-  <p>
-     
-     
-  </p>
-  <ParticipantButton
-    eventId={1}
-    hasEventWaitlist={true}
-    onClick={[Function]}
-  />
+  <div>
+    <p>
+       
+       
+    </p>
+    <ParticipantButton
+      eventId={1}
+      hasEventWaitlist={true}
+      onClick={[Function]}
+    />
+  </div>
 </div>
 `;
 
 exports[`ParticipantForm renders participant form component when user has already registered for the event renders CancelRegistrationButton component. 1`] = `
 <div>
-  <p>
-     
-     
-  </p>
-  <CancelRegistrationButton
-    eventId={1}
-    onClick={[Function]}
-  />
+  <div>
+    <p>
+       
+       
+    </p>
+    <CancelRegistrationButton
+      eventId={1}
+      onClick={[Function]}
+    />
+  </div>
 </div>
 `;

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -5,8 +5,9 @@ import CancelRegistrationButton from '../buttons/CancelRegistrationButton'
 
 type Props = {
   eventId: ?number,
-  hasEventWaitlist: boolean,
+  isSignedIn: boolean,
   isUserRegistered: boolean,
+  hasEventWaitlist: boolean,
   message: string,
   onSubmit: Function,
   onCancel: Function,
@@ -19,18 +20,22 @@ const ParticipantForm = (props: Props) => {
 
   return (
     <div>
-      <p> { props.message } </p>
-      { props.isUserRegistered ?
-        <CancelRegistrationButton
-          eventId={eventId}
-          onClick={onCancel}
-        /> :
-        <ParticipantButton
-          eventId={eventId}
-          hasEventWaitlist={hasEventWaitlist}
-          onClick={onSubmit}
-        />
-      }
+      { props.isSignedIn &&
+        <div>
+          <p> { props.message } </p>
+          { props.isUserRegistered ?
+            <CancelRegistrationButton
+              eventId={eventId}
+              onClick={onCancel}
+            /> :
+            <ParticipantButton
+              eventId={eventId}
+              hasEventWaitlist={hasEventWaitlist}
+              onClick={onSubmit}
+            />
+          }
+        </div>
+    }
     </div>
   )
 }

--- a/containers/EventView.js
+++ b/containers/EventView.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import Error from 'next/error'
+import withAuth from '../components/Auth'
 import withProvider from '../components/Provider'
 import { fetchEvent, registerForEvent, cancelRegistration } from '../actions/event'
 import { getCurrentEvent, getHasWaitlist, getHasNotFoundError } from '../selectors/event'
@@ -14,9 +15,11 @@ import EventComponent from '../components/Event'
 import ParticipantFormComponent from '../components/ParticipantForm'
 import ParticipantsListComponent from '../components/ParticipantsList'
 import type { EventId, EventProps } from '../types/Event'
+import type { SessionType } from '../components/Auth'
 
 type Props = {
   url: { query: EventId },
+  session: SessionType,
   event: EventProps,
   hasNotFoundError: boolean,
   hasWaitlist: boolean,
@@ -45,6 +48,7 @@ class EventView extends React.Component<Props> {
           <EventComponent event={event} />
           <ParticipantFormComponent
             eventId={event.id}
+            isSignedIn={this.props.session.isSignedIn}
             isUserRegistered={event.registered}
             hasEventWaitlist={this.props.hasWaitlist}
             message={this.props.participantMessage}
@@ -73,4 +77,4 @@ const mapDispatchToProps = {
   cancelRegistration,
 }
 
-export default withProvider(connect(mapStateToProps, mapDispatchToProps)(EventView))
+export default withProvider(connect(mapStateToProps, mapDispatchToProps)(withAuth(EventView)))


### PR DESCRIPTION
### Overview:概要
ユーザーがサインインしていない場合、イベントページで参加登録ボタンが表示されないようにする。

### Technical changes:技術的変更点
- サインイン状態の判定
高階コンポーネント`withAuth`を使用して`session.isSignedIn`プロパティを`ParticipantForm` コンポーネントに追加する
- 高階コンポーネント `withAuth` の変更
`withAuth`を他の高階コンポーネントと併用できるよう戻り値がstateだけでなくプロパティも引き継ぐよう変更

下記の理由から、`withAuth`はEventViewコンテナに追加しています。もっと良い方法があればご教示ください！
- 他のコンポーネントでもユーザー情報を使用する可能性を考慮
- Next.js を使わなくなった場合にpages に追加するより影響が小さい

### Impact point:変更に関する影響箇所
サインインしていない場合には参加登録ボタンが表示されなくなる

### Change of UserInterface:UIの変更
変更前
![screenshot from 2018-04-30 20-28-07](https://user-images.githubusercontent.com/10824691/39425167-286809f2-4cb5-11e8-93bd-21396dbb5dc1.png)

変更後
![screenshot from 2018-04-30 20-28-30](https://user-images.githubusercontent.com/10824691/39425174-2db7b560-4cb5-11e8-8d81-ac607e511ddc.png)

