### PR TITLE
Add SessionProvider to ParticipantForm

### DIFF
--- a/components/ParticipantForm/__tests__/ParticipantForm.spec.js
+++ b/components/ParticipantForm/__tests__/ParticipantForm.spec.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
-import ParticipantForm from '../index'
+import { ParticipantForm } from '../index'
 
 const testProps = {
   eventId: 1,
   hasEventWaitlist: true,
-  isSignedIn: true,
   isUserRegistered: false,
   message: null,
   onSubmit: () => {},
@@ -34,16 +33,6 @@ describe('ParticipantForm', () => {
       it('renders ParticipantButton component.', () => {
         const wrapper =
           shallow(<ParticipantForm {...testProps} />)
-        const tree = shallowToJson(wrapper)
-
-        expect(tree).toMatchSnapshot()
-      })
-    })
-
-    describe('when user NOT signed in', () => {
-      it('renders nothig.', () => {
-        const wrapper =
-          shallow(<ParticipantForm {...testProps} isSignedIn={false} />)
         const tree = shallowToJson(wrapper)
 
         expect(tree).toMatchSnapshot()

--- a/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
+++ b/components/ParticipantForm/__tests__/__snapshots__/ParticipantForm.spec.js.snap
@@ -2,50 +2,42 @@
 
 exports[`ParticipantForm on completing registeration for event renders completion message 1`] = `
 <div>
-  <div>
-    <p>
-       
-      参加登録が完了しました。
-       
-    </p>
-    <ParticipantButton
-      eventId={1}
-      hasEventWaitlist={true}
-      onClick={[Function]}
-    />
-  </div>
+  <p>
+     
+    参加登録が完了しました。
+     
+  </p>
+  <ParticipantButton
+    eventId={1}
+    hasEventWaitlist={true}
+    onClick={[Function]}
+  />
 </div>
 `;
 
-exports[`ParticipantForm renders participant form component when user NOT signed in renders nothig. 1`] = `<div />`;
-
 exports[`ParticipantForm renders participant form component when user has NOT registered for the event yet renders ParticipantButton component. 1`] = `
 <div>
-  <div>
-    <p>
-       
-       
-    </p>
-    <ParticipantButton
-      eventId={1}
-      hasEventWaitlist={true}
-      onClick={[Function]}
-    />
-  </div>
+  <p>
+     
+     
+  </p>
+  <ParticipantButton
+    eventId={1}
+    hasEventWaitlist={true}
+    onClick={[Function]}
+  />
 </div>
 `;
 
 exports[`ParticipantForm renders participant form component when user has already registered for the event renders CancelRegistrationButton component. 1`] = `
 <div>
-  <div>
-    <p>
-       
-       
-    </p>
-    <CancelRegistrationButton
-      eventId={1}
-      onClick={[Function]}
-    />
-  </div>
+  <p>
+     
+     
+  </p>
+  <CancelRegistrationButton
+    eventId={1}
+    onClick={[Function]}
+  />
 </div>
 `;

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -1,11 +1,13 @@
 // @flow
 import React from 'react'
+
+import { SessionConsumer } from '../SessionProvider'
+
 import ParticipantButton from '../buttons/ParticipantButton'
 import CancelRegistrationButton from '../buttons/CancelRegistrationButton'
 
 type Props = {
   eventId: ?number,
-  isSignedIn: boolean,
   isUserRegistered: boolean,
   hasEventWaitlist: boolean,
   message: string,
@@ -13,31 +15,35 @@ type Props = {
   onCancel: Function,
 }
 
-const ParticipantForm = (props: Props) => {
+export const ParticipantForm = (props: Props) => {
   const {
     eventId, onSubmit, onCancel, hasEventWaitlist,
   } = props
 
   return (
     <div>
-      { props.isSignedIn &&
-        <div>
-          <p> { props.message } </p>
-          { props.isUserRegistered ?
-            <CancelRegistrationButton
-              eventId={eventId}
-              onClick={onCancel}
-            /> :
-            <ParticipantButton
-              eventId={eventId}
-              hasEventWaitlist={hasEventWaitlist}
-              onClick={onSubmit}
-            />
-          }
-        </div>
-    }
+      <p> { props.message } </p>
+      { props.isUserRegistered ?
+        <CancelRegistrationButton
+          eventId={eventId}
+          onClick={onCancel}
+        /> :
+        <ParticipantButton
+          eventId={eventId}
+          hasEventWaitlist={hasEventWaitlist}
+          onClick={onSubmit}
+        />
+      }
     </div>
   )
 }
 
-export default ParticipantForm
+ParticipantForm.displayName = 'ParticipantForm'
+
+const ParticipantFormWithSession = (props: Props) => (
+  <SessionConsumer>
+    { (session: any) => (session.isSignedIn ? <ParticipantForm {...props} /> : null) }
+  </SessionConsumer>
+)
+
+export default ParticipantFormWithSession

--- a/components/SessionProvider/index.js
+++ b/components/SessionProvider/index.js
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react'
+import type { ComponentType } from 'react'
+import type { SessionType } from '../Auth'
+import withAuth from '../Auth'
+
+const { Provider, Consumer } = React.createContext()
+
+type ProviderType = {
+  session: SessionType,
+  children: ComponentType<*>
+}
+
+const withSessionProvider = (props: ProviderType) => (
+  <Provider value={props.session}>
+    {props.children}
+  </Provider>
+)
+
+export const SessionProvider = withAuth(withSessionProvider)
+export const SessionConsumer = Consumer

--- a/containers/EventView.js
+++ b/containers/EventView.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import Error from 'next/error'
-import withAuth from '../components/Auth'
+import { SessionProvider } from '../components/SessionProvider'
 import withProvider from '../components/Provider'
 import { fetchEvent, registerForEvent, cancelRegistration } from '../actions/event'
 import { getCurrentEvent, getHasWaitlist, getHasNotFoundError } from '../selectors/event'
@@ -15,11 +15,9 @@ import EventComponent from '../components/Event'
 import ParticipantFormComponent from '../components/ParticipantForm'
 import ParticipantsListComponent from '../components/ParticipantsList'
 import type { EventId, EventProps } from '../types/Event'
-import type { SessionType } from '../components/Auth'
 
 type Props = {
   url: { query: EventId },
-  session: SessionType,
   event: EventProps,
   hasNotFoundError: boolean,
   hasWaitlist: boolean,
@@ -43,12 +41,11 @@ class EventView extends React.Component<Props> {
       this.props.hasNotFoundError ?
         <Error statusCode="404" />
         :
-        <div>
+        <SessionProvider>
           <h3>This is the event page!</h3>
           <EventComponent event={event} />
           <ParticipantFormComponent
             eventId={event.id}
-            isSignedIn={this.props.session.isSignedIn}
             isUserRegistered={event.registered}
             hasEventWaitlist={this.props.hasWaitlist}
             message={this.props.participantMessage}
@@ -58,7 +55,7 @@ class EventView extends React.Component<Props> {
           <ParticipantsListComponent
             participants={this.props.participants}
           />
-        </div>
+        </SessionProvider>
     )
   }
 }
@@ -77,4 +74,4 @@ const mapDispatchToProps = {
   cancelRegistration,
 }
 
-export default withProvider(connect(mapStateToProps, mapDispatchToProps)(withAuth(EventView)))
+export default withProvider(connect(mapStateToProps, mapDispatchToProps)(EventView))

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-jest": "^21.5.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.0",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.72.0",
     "jest": "^21.2.1",
     "moxios": "^0.4.0",
     "react-test-renderer": "^16.2.0",

--- a/pages/auth/callback.js
+++ b/pages/auth/callback.js
@@ -2,14 +2,14 @@
 import React, { Component } from 'react'
 import Router from 'next/router'
 import { setAuthInfo, getAuthParams } from '../../utils/auth'
-import type { AuthInfo } from '../../utils/auth'
+import type { AuthInfo, AuthQueryParams } from '../../utils/auth'
 
 type Props = {
   authInfo: AuthInfo,
 }
 
 export default class AuthCallback extends Component<Props> {
-  static async getInitialProps(ctx) {
+  static async getInitialProps(ctx: { query: AuthQueryParams }) {
     return ctx.query ? {
       authInfo: getAuthParams(ctx.query),
     } : {}

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -8,7 +8,7 @@ export type AuthInfo = {
   uid: string,
 }
 
-type AuthQueryParams = {
+export type AuthQueryParams = {
   auth_token: string,
   client_id: string,
   uid: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2451,9 +2451,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.57.3:
-  version "0.57.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
+flow-bin@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.72.0.tgz#12051180fb2db7ccb728fefe67c77e955e92a44d"
 
 flux-standard-action@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
### Overview:概要
現状ではParticipantForm Component で直接セッション情報を取得することにより、参加登録フォームの表示／非表示を切り替えている。
セッション情報は他のコンポーネントでも必要となることが予想されるため、セッション状態をContextから取得するよう変更する。

### Technical changes:技術的変更点
React の Context Provider を使用して、以下の構造でセッション情報を共有する。
- SessionProvider Componentでセッション情報を取得、SessionProvider と SessionConsumer を作成する
- EventView Container で SessionProvider を使用、配下の Component でセッション情報を呼び出せるようにする
- ParticipantForm で ProviderConsumer を使用してセッション情報を取得、フォームの表示／非表示を切り替える

また、本PRで導入するReact.createContext APIに対応するため、Flowのアップグレードを行う。
Flow アップグレード後に新た型チェックによる指摘があった箇所についても修正を行っている。

### Impact point:変更に関する影響箇所
EventView Container 配下の Component では、SessionConsumer を使用してセッション状態が取得できるようになる。

### Change of UserInterface:UIの変更
UI の変更はなし