### PR TITLE
Add validation to event start and end datetime form

### DIFF
--- a/components/EventForm/index.js
+++ b/components/EventForm/index.js
@@ -10,7 +10,7 @@ type Props = {
   validationFailed: boolean,
 }
 
-type State = {
+export type EventState = {
   name: string,
   description: string,
   quota: number,
@@ -18,7 +18,7 @@ type State = {
   eventEndsAt: string,
 }
 
-export default class EventForm extends Component<Props, State> {
+export default class EventForm extends Component<Props, EventState> {
   constructor(props: Props) {
     super(props)
     this.state = {
@@ -27,8 +27,7 @@ export default class EventForm extends Component<Props, State> {
   }
 
   onBlurHandler = (e: SyntheticInputEvent<>) => {
-    const { id, value } = e.target
-    this.props.onValidation(id, value)
+    this.props.onValidation(e.target.id, this.state)
   }
 
   onChangeHandler = (e: SyntheticInputEvent<>) => {
@@ -37,7 +36,7 @@ export default class EventForm extends Component<Props, State> {
       ...this.state,
       [id]: value,
     })
-    this.props.onValidation(id, value)
+    this.props.onValidation(id, this.state)
   }
 
   onSubmitHandler = (e: SyntheticEvent<>) => {

--- a/reducers/eventForm.js
+++ b/reducers/eventForm.js
@@ -13,6 +13,14 @@ export const eventFormInitialState = new Map({
     validationPassed: false,
     errors: new List(),
   }),
+  eventStartsAt: new Map({
+    validationPassed: false,
+    errors: new List(),
+  }),
+  eventEndsAt: new Map({
+    validationPassed: false,
+    errors: new List(),
+  }),
 })
 
 const validateEventForm = {

--- a/selectors/__tests__/EventFormSelector.spec.js
+++ b/selectors/__tests__/EventFormSelector.spec.js
@@ -2,7 +2,6 @@ import { Map, List } from 'immutable'
 import * as EventFormSelector from '../eventForm'
 
 const nameErrorMessages = ['nameは必須です。']
-const quotaErrorMessages = []
 
 const testEventFormState = new Map({
   name: new Map({
@@ -11,7 +10,15 @@ const testEventFormState = new Map({
   }),
   quota: new Map({
     validationPassed: true,
-    errors: new List(quotaErrorMessages),
+    errors: new List([]),
+  }),
+  eventStartsAt: new Map({
+    validationPassed: true,
+    errors: new List([]),
+  }),
+  eventEndsAt: new Map({
+    validationPassed: true,
+    errors: new List([]),
   }),
 })
 const mockState = { eventForm: testEventFormState }
@@ -22,7 +29,9 @@ describe('EventFormSelector', () => {
       const subject = EventFormSelector.getValidationErrorMessages(mockState)
       expect(subject).toEqual({
         name: nameErrorMessages,
-        quota: quotaErrorMessages,
+        quota: [],
+        eventStartsAt: [],
+        eventEndsAt: [],
       })
     })
   })

--- a/selectors/eventForm.js
+++ b/selectors/eventForm.js
@@ -3,6 +3,8 @@ import { createSelector } from 'reselect'
 
 const getNameErrorList = (state: Object) => state.eventForm.getIn(['name', 'errors'])
 const getQuotaErrorList = (state: Object) => state.eventForm.getIn(['quota', 'errors'])
+const getStartsAtErrorList = (state: Object) => state.eventForm.getIn(['eventStartsAt', 'errors'])
+const getEndsAtErrorList = (state: Object) => state.eventForm.getIn(['eventEndsAt', 'errors'])
 
 const isNameValidationFailed = (state: Object) => (
   !state.eventForm.getIn(['name', 'validationPassed'])
@@ -10,18 +12,33 @@ const isNameValidationFailed = (state: Object) => (
 const isQuotaValidationFailed = (state: Object) => (
   !state.eventForm.getIn(['quota', 'validationPassed'])
 )
+const isStartsAtValidationFailed = (state: Object) => (
+  !state.eventForm.getIn(['eventStartsAt', 'validationPassed'])
+)
+const isEndsAtValidationFailed = (state: Object) => (
+  !state.eventForm.getIn(['eventEndsAt', 'validationPassed'])
+)
 
 export const getValidationErrorMessages =
   createSelector(
-    [getNameErrorList, getQuotaErrorList],
-    (nameErrorList, quotaErrorList) => ({
+    [getNameErrorList, getQuotaErrorList, getStartsAtErrorList, getEndsAtErrorList],
+    (nameErrorList, quotaErrorList, startsAtErrorList, endsAtErrorList) => ({
       name: nameErrorList.toArray(),
       quota: quotaErrorList.toArray(),
+      eventStartsAt: startsAtErrorList.toArray(),
+      eventEndsAt: endsAtErrorList.toArray(),
     }),
   )
 
 export const isValidationFailed =
   createSelector(
-    [isNameValidationFailed, isQuotaValidationFailed],
-    (isNameFailed, isQuotaFailed) => isNameFailed || isQuotaFailed,
+    [
+      isNameValidationFailed,
+      isQuotaValidationFailed,
+      isStartsAtValidationFailed,
+      isEndsAtValidationFailed,
+    ],
+    (isNameFailed, isQuotaFailed, isStartsAtFailed, isEndsAtFailed) => (
+      isNameFailed || isQuotaFailed || isStartsAtFailed || isEndsAtFailed
+    ),
   )

--- a/validators/__tests__/eventFormValidator.spec.js
+++ b/validators/__tests__/eventFormValidator.spec.js
@@ -1,7 +1,7 @@
 import eventFormValidator from '../eventFormValidator'
 
 const id = 'name'
-const value = 'event1'
+const value = { name: 'event1' }
 
 const passedResult = {
   id,

--- a/validators/eventFormValidator.js
+++ b/validators/eventFormValidator.js
@@ -1,16 +1,23 @@
 // @flow
 import BaseValidator from './BaseValidator'
+import type{ EventState } from '../components/EventForm'
 
 const rules = {
   name: 'required',
   quota: 'required|numeric|min:1|max:1000',
+  eventStartsAt: 'required',
+  eventEndsAt: 'required|after_or_equal:eventStartsAt',
 }
 
-export default (id: string, value: string) => {
-  const rule = rules[id]
-  if (rule) {
-    const validator = new BaseValidator({ [id]: value }, { [id]: rule })
+// This custom message is needed until next release of validatorjs package.
+const dateErrorMessage =
+  { after_or_equal: 'イベント終了日はイベント開始日より後の日付を入力してください。' }
+
+export default (id: string, state: EventState) => {
+  if (rules[id]) {
+    const validator = new BaseValidator({ ...state }, { [id]: rules[id] }, dateErrorMessage)
     return { id, validationPassed: validator.passes(), errors: validator.errors.get(id) }
   }
+
   return { id, validationPassed: true, errors: [] }
 }


### PR DESCRIPTION
### Overview:概要
イベントの開始／終了時刻の入力フォームに対して、以下のバリデーションを追加する。
- 入力必須
- 開始時刻が終了時刻を超えないこと

### Technical changes:技術的変更点
- EventFormValidtor に eventStartsAt と eventEndsAt のバリデーションを追加
  - eventStartsAtは `require` を設定
  - eventEndsAtは `require｜after:eventStartsAt` を設定
開始時刻が終了時刻を超えないことについては、eventStartsAt と eventEndsAt のそれぞれにも設定できる。しかし２つのエラーメッセージが出力されるのは冗長なので、eventEndsAtのみとする。
通常、eventStartsAt → eventEndsAt の順に入力されるはずなので、両方の入力が確定するであろうeventEndsAtが入力された時点でバリデーションを行う。
- EventFormSelector
  - eventStartsAt と eventEndsAt のエラーメッセージを追加
  - eventStartsAt と eventEndsAt が正しいことを送信が可能となる条件に追加
 
- `validatorjs` パッケージでは、開始時刻が終了時刻を超えた場合の日本語のエラーメッセージが存在しない。このエラーメッセージを追加するPRを送付し、merge 待ちとなっている。
### Impact point:変更に関する影響箇所
イベントの開始／終了時刻を正しく入力しなければ、バックエンドに送信できなくなる。

### Change of UserInterface:UIの変更
UIの変更はなし

### TODOs
- [x] EventFormSelector にeventStartsAt と eventEndsAt のエラーメッセージと送信可能条件を追加
- [x] 入力必須のバリデーションを追加
- [x]  開始時刻が終了時刻を超えないことのバリデーションを追加
- [x] バリデーションエラーメッセージの日本語対応（`validatorjs`パッケージのPRマージ待ち）
- [x] `validatorjs`パッケージのマージされたPRを含んだバージョンのリリースまでは独自でメッセージを追加する