### PR TITLE
Change event start and end date to send with local timezone offset

### DIFF
--- a/api/Event.js
+++ b/api/Event.js
@@ -11,7 +11,7 @@ type createProps = {
   eventEndsAt: string,
 }
 
-const toUTCString = (datetime: string) => moment(datetime).utc().toISOString()
+const toISOString = (datetime: string) => moment(datetime).format()
 
 export default class Event extends Base {
   cancelRegistration = (params: number) => {
@@ -22,8 +22,8 @@ export default class Event extends Base {
   createEvent = (params: createProps) => {
     const createParams = {
       ...params,
-      eventStartsAt: toUTCString(params.eventStartsAt),
-      eventEndsAt: toUTCString(params.eventEndsAt),
+      eventStartsAt: toISOString(params.eventStartsAt),
+      eventEndsAt: toISOString(params.eventEndsAt),
     }
 
     return this.create(createParams)

--- a/api/__tests__/Event.spec.js
+++ b/api/__tests__/Event.spec.js
@@ -71,8 +71,8 @@ describe('Event', () => {
             const requestParams = moxios.requests.mostRecent().config.data
             // should no offset
             expect(JSON.parse(requestParams)).toEqual(expect.objectContaining({
-              event_starts_at: '2018-03-01T09:00:00.000Z',
-              event_ends_at: '2018-03-01T17:00:00.000Z',
+              event_starts_at: '2018-03-01T09:00:00Z',
+              event_ends_at: '2018-03-01T17:00:00Z',
             }))
           })
         })
@@ -89,10 +89,10 @@ describe('Event', () => {
 
           return event.createEvent(params).then(() => {
             const requestParams = moxios.requests.mostRecent().config.data
-            // should -9 hours as offset of Asia/Tokyo timezone
+            // should +9 hours as offset of Asia/Tokyo timezone
             expect(JSON.parse(requestParams)).toEqual(expect.objectContaining({
-              event_starts_at: '2018-03-01T00:00:00.000Z',
-              event_ends_at: '2018-03-01T08:00:00.000Z',
+              event_starts_at: '2018-03-01T09:00:00+09:00',
+              event_ends_at: '2018-03-01T17:00:00+09:00',
             }))
           })
         })


### PR DESCRIPTION
### Overview:概要
5/24 のミーティング時に指摘のあった、イベントの開始／終了時刻をUTC時刻に変換せず、ローカルのタイムゾーンんのオフセットを付与して送信する修正です。

### Technical changes:技術的変更点
-  イベント新規作成時に、Event APIでは、`format` メソッドによる、ISO8601形式のローカルタイムゾーンのオフセット付きの時刻への変換を行う

### Impact point:変更に関する影響箇所
バックエンドに送信されるイベントの開始／終了時刻が、例えば`Asia/Tokyo` タイムゾーンなら以下となる。
`2018-05-01T09:00:00+09:00`  （UTC時刻から＋９時間のオフセット）

### Change of UserInterface:UIの変更
変更なし