### PR TITLE
Check if after the deadline in ParticipantForm Component

### DIFF
--- a/components/AfterDeadline/index.js
+++ b/components/AfterDeadline/index.js
@@ -1,0 +1,8 @@
+// @flow
+import React from 'react'
+
+const AfterDeadline = () => (
+  <p>参加登録は締め切りました</p>
+)
+
+export default AfterDeadline

--- a/components/ParticipantForm/index.js
+++ b/components/ParticipantForm/index.js
@@ -1,8 +1,9 @@
 // @flow
 import React from 'react'
 
-import { SessionConsumer } from '../SessionProvider'
+import { toggleComponentsBySession } from '../SessionProvider'
 
+import AfterDeadline from '../AfterDeadline'
 import ParticipantButton from '../buttons/ParticipantButton'
 import CancelRegistrationButton from '../buttons/CancelRegistrationButton'
 
@@ -33,17 +34,22 @@ export const ParticipantForm = (props: Props) => {
           hasEventWaitlist={hasEventWaitlist}
           onClick={onSubmit}
         />
-      }
+       }
     </div>
   )
 }
 
 ParticipantForm.displayName = 'ParticipantForm'
 
-const ParticipantFormWithSession = (props: Props) => (
-  <SessionConsumer>
-    { (session: any) => (session.isSignedIn ? <ParticipantForm {...props} /> : null) }
-  </SessionConsumer>
+const ParticipantFormWithDeadline = ({ isEventWithinDeadline, ...props }: any) => (
+  <div>
+    { isEventWithinDeadline ? <ParticipantForm {...props} /> : <AfterDeadline /> }
+  </div>
 )
+
+ParticipantFormWithDeadline.displayName = 'ParticipantFormWithDeadline'
+
+const ParticipantFormWithSession =
+  toggleComponentsBySession(ParticipantFormWithDeadline, () => <div />)
 
 export default ParticipantFormWithSession

--- a/components/SessionProvider/index.js
+++ b/components/SessionProvider/index.js
@@ -17,5 +17,16 @@ const withSessionProvider = (props: ProviderType) => (
   </Provider>
 )
 
+export const toggleComponentsBySession =
+  (SignedInComponent: ComponentType<*>, NotSignedInComponent: ComponentType<*>) => (
+    (props: any) => (
+      <Consumer>
+        { (session: any) => (
+        session.isSignedIn ?
+          <SignedInComponent {...props} /> : <NotSignedInComponent {...props} />
+      ) }
+      </Consumer>
+    )
+  )
+
 export const SessionProvider = withAuth(withSessionProvider)
-export const SessionConsumer = Consumer

--- a/containers/EventView.js
+++ b/containers/EventView.js
@@ -55,6 +55,7 @@ class EventView extends React.Component<Props> {
             eventId={event.id}
             isUserRegistered={userParticipation.registered}
             hasEventWaitlist={this.props.hasWaitlist}
+            isEventWithinDeadline={event.withinDeadline}
             message={this.props.participantMessage}
             onSubmit={this.props.registerForEvent}
             onCancel={this.props.cancelRegistration}

--- a/factories/Event.js
+++ b/factories/Event.js
@@ -6,11 +6,12 @@ export default {
     quota: 10,
     eventStartsAt: '2018-03-01T09:00:00',
     eventEndsAt: '2018-03-01T17:00:00',
-    participants: [],
+    withinDeadline: true,
     userParticipation: {
       registered: true,
       onWaitingList: false,
     },
+    participants: [],
   },
   errorEvent: {
     id: 1,
@@ -20,10 +21,11 @@ export default {
     errors: ['nameを入力してください', 'nameは１０文字以内です'],
     eventStartsAt: '2018-03-01T09:00:00',
     eventEndsAt: '2018-03-01T17:00:00',
-    participants: [],
+    withinDeadline: true,
     userParticipation: {
       registered: false,
       onWaitingList: false,
     },
+    participants: [],
   },
 }

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -15,6 +15,7 @@ export const eventInitialState = new Map({
       quota: 0,
       eventStartsAt: null,
       eventEndsAt: null,
+      withinDeadline: false,
       userParticipation: new Map({
         registered: false,
         onWaitingList: false,

--- a/types/Event.js
+++ b/types/Event.js
@@ -11,6 +11,7 @@ export type EventProps = {
   quota: number,
   eventStartsAt: string,
   eventEndsAt: string,
+  withinDeadline: boolean,
   participants: Object[],
   errors: ?string[]
 }


### PR DESCRIPTION
### Overview:概要
イベント詳細ページの参加登録フォームについて、イベントの開始時刻を過ぎた場合には登録できないようにする。

### Technical changes:技術的変更点
- イベントの参加締め切りを超えていないかを示す、withinDeadline属性をEventReducerに追加
- ParticipantForm Component では参加できる場合はフォームを、締切の場合はAfterDeadline Componentを表示するHOCを追加
- 本PRとは直接関係ないがリファクタリングの一環として、サインイン状態により、表示するコンポーネントを切り替えるtoggleComponentsBySession 関数を追加。これによりサインイン状態による表示の切替が容易に実装できる。

### Impact point:変更に関する影響箇所
開始時刻を過ぎたイベントには申し込み処理が行えなくなる。

### Change of UserInterface:UIの変更
締め切られた場合：
![image](https://user-images.githubusercontent.com/10824691/42130077-2175d28a-7d13-11e8-8b52-00450a1f0b98.png)

申し込み期限内の場合：
![image](https://user-images.githubusercontent.com/10824691/42130079-431b13f0-7d13-11e8-99fc-f34119cd9cdd.png)

### TODOs
- [x] 機能の実装
- [x] 他PRとのコンフリクトの解消