### PR TITLE
Recursively converting case of object keys for API response data

### DIFF
--- a/api/Base.js
+++ b/api/Base.js
@@ -14,7 +14,7 @@ export default class Base {
   }
 
   onSuccess(response: Object) {
-    return response.data
+    return ConvertCase.camelKeysOf(response.data)
   }
 
   onFailure(error: Object): Promise<Error> {

--- a/reducers/__tests__/EventReducer.spec.js
+++ b/reducers/__tests__/EventReducer.spec.js
@@ -10,16 +10,10 @@ import ParticipantParams from '../../factories/Participant'
 
 const { participant1 } = ParticipantParams
 const { event1 } = EventParams
-const { eventStartsAt, eventEndsAt, ...otherEvent1Params } = event1
-const eventEntity = {
-  ...otherEvent1Params,
-  event_starts_at: eventStartsAt,
-  event_ends_at: eventEndsAt,
-}
 
 const eventPayload = {
   result: event1.id,
-  entities: { event: { [event1.id]: eventEntity } },
+  entities: { event: { [event1.id]: event1 } },
   errors: [],
 }
 

--- a/reducers/event.js
+++ b/reducers/event.js
@@ -1,16 +1,10 @@
 // @flow
 import { handleActions } from 'redux-actions'
 import { Map, List } from 'immutable'
-import _ from 'lodash'
 
 import Actions from '../constants/Actions'
-import ConvertCase from '../utils/ConvertCase'
 
 const initialId = 0
-
-const toCamelCase = payload => (
-  _.mapValues(payload, val => ConvertCase.camelKeysOf(val))
-)
 
 export const eventInitialState = new Map({
   entityId: initialId,
@@ -32,7 +26,7 @@ const setEvent = {
   next: (state, action) => (
     state.merge({
       entityId: action.payload.result,
-      entities: toCamelCase(action.payload.entities.event),
+      entities: action.payload.entities.event,
       errors: [],
     })
   ),

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -1,10 +1,8 @@
 // @flow
 import { handleActions } from 'redux-actions'
 import { Map, List } from 'immutable'
-import _ from 'lodash'
 
 import Actions from '../constants/Actions'
-import ConvertCase from '../utils/ConvertCase'
 import Messages from '../constants/Messages'
 
 export const participantInitialState = new Map({
@@ -12,10 +10,6 @@ export const participantInitialState = new Map({
   errors: new List(),
   message: null,
 })
-
-const toCamelCase = payload => (
-  _.mapValues(payload, val => ConvertCase.camelKeysOf(val))
-)
 
 const { admittedRegestration, waitlistedRegestration } = Messages.Participants
 const participationCompleteMessage = onWaitingList => (
@@ -26,7 +20,7 @@ const participantReducerMap = {
   [Actions.Event.fetchEvent]: {
     next: (state, action) => (
       state.merge({
-        entities: toCamelCase(action.payload.entities.participant),
+        entities: action.payload.entities.participant,
         errors: [],
       })
     ),
@@ -34,7 +28,7 @@ const participantReducerMap = {
 
   [Actions.Event.registerForEvent]: {
     next: (state, action) => {
-      const participant = toCamelCase(action.payload.entities.participant)
+      const { participant } = action.payload.entities
       const { onWaitingList } = participant[action.payload.result]
       return state.mergeDeep({
         entities: participant,
@@ -48,7 +42,7 @@ const participantReducerMap = {
   [Actions.Event.cancelRegistration]: {
     next: (state, action) => (
       state.merge({
-        entities: toCamelCase(action.payload.entities.participant),
+        entities: action.payload.entities.participant,
         errors: [],
       })
     ),

--- a/utils/ConvertCase.js
+++ b/utils/ConvertCase.js
@@ -1,17 +1,24 @@
 // @flow
 import _ from 'lodash'
 
-const convertKeys = (dict, converter) => (
-  _.mapKeys(dict, (v, k) => converter(k))
-)
+const convertKeysInDeep = (obj, converter) => {
+  if (!_.isObject(obj)) { return obj }
+
+  if (_.isArray(obj)) { return obj.map(v => convertKeysInDeep(v, converter)) }
+
+  return _.chain(obj)
+    .mapKeys((v, k) => converter(k))
+    .mapValues(v => convertKeysInDeep(v, converter))
+    .value()
+}
 
 const ConvertCase = {
-  camelKeysOf(dict: Object) {
-    return convertKeys(dict, _.camelCase)
+  camelKeysOf(obj: Object) {
+    return convertKeysInDeep(obj, _.camelCase)
   },
 
-  snakeKeysOf(dict: Object) {
-    return convertKeys(dict, _.snakeCase)
+  snakeKeysOf(obj: Object) {
+    return convertKeysInDeep(obj, _.snakeCase)
   },
 }
 

--- a/utils/__tests__/ConvertCase.spec.js
+++ b/utils/__tests__/ConvertCase.spec.js
@@ -4,11 +4,19 @@ describe('ConvertCase', () => {
   const camelKeysParams = {
     eventId: 1,
     name: 'name',
+    userParticipation: {
+      registered: true,
+      onWaitingList: true,
+    },
   }
 
   const snakeKeysParams = {
     event_id: 1,
     name: 'name',
+    user_participation: {
+      registered: true,
+      on_waiting_list: true,
+    },
   }
 
   describe('.camelKeysOf()', () => {


### PR DESCRIPTION
### Overview:概要
ネストされたオブジェクトに対して、現状ではキーを再帰的にキャメルケース／スネークケースに変換できない。
このため、各モデルの Reducer でそれぞれキーを変換している。
そこで、再帰的にキーを変換できるようにし、APIのデータ受信時に一括で変換を行い、処理をシンプルにする。

### Technical changes:技術的変更点
- オブジェクトの各プロパティに対して、以下の場合分けをしながら再帰的にキーを変換する。
  - プリミティブな値なら、そのまま返す
  - 配列 なら、各要素に変換処理を再帰的に呼び出し、配列で返す
  - オブジェクトなら、キー名を変換し、値に対して変換処理を再帰呼び出し

- キーの変換処理はAPI通信のコールバックで受け取ったレスポンスに直接実施

### Impact point:変更に関する影響箇所
Reducerで行っていたキーの変換処理は不要となる。

### Change of UserInterface:UIの変更
変更なし