### PR TITLE
Fix a bug in Participant Reducer accessing unexisting participant entity

### DIFF
--- a/reducers/__tests__/ParticipantReducer.spec.js
+++ b/reducers/__tests__/ParticipantReducer.spec.js
@@ -48,6 +48,27 @@ describe('Participant Reducer', () => {
           message: null,
         })
 
+        expect(subject).toEqual(expectedState)
+      })
+    })
+
+    describe('with success event fetch with no participants', () => {
+      it('should return blank entity', () => {
+        const payload = {
+          result: event1.id,
+          entities: {
+            event: { [event1.id]: { ...event1, participants: [] } },
+            errors: [],
+          },
+        }
+
+        const subject = ParticipantReducer(participantInitialState, fetchEvent(payload))
+
+        const expectedState = new Map({
+          entities: new Map({}),
+          errors: new List(),
+          message: null,
+        })
 
         expect(subject).toEqual(expectedState)
       })
@@ -171,6 +192,42 @@ describe('Participant Reducer', () => {
         const subject = ParticipantReducer(prevState, cancelRegistration(payload))
 
         const expectedState = prevState.deleteIn(['entities', `${participant2.id}`])
+
+        expect(subject).toEqual(expectedState)
+      })
+    })
+
+    describe('with success cancel registration and no participants', () => {
+      it('should return blank entity ', () => {
+        const prevState = new Map({
+          entities: new Map({
+            [participant1.id]: new Map({ ...participant1 }),
+          }),
+          errors: new List(),
+          message: null,
+        })
+
+        const cancelledEvent = {
+          ...event1,
+          participants: [],
+          userParticipation: { regitered: true, onWaitingList: false },
+        }
+
+        const payload = {
+          result: event1.id,
+          entities: {
+            event: { [event1.id]: cancelledEvent },
+            errors: [],
+          },
+        }
+
+        const subject = ParticipantReducer(prevState, cancelRegistration(payload))
+
+        const expectedState = new Map({
+          entities: new Map({}),
+          errors: new List(),
+          message: null,
+        })
 
         expect(subject).toEqual(expectedState)
       })

--- a/reducers/participant.js
+++ b/reducers/participant.js
@@ -44,7 +44,7 @@ const participantReducerMap = {
   [Actions.Event.cancelRegistration]: {
     next: (state, action) => (
       state.merge({
-        entities: action.payload.entities.participant,
+        entities: action.payload.entities.participant || {},
         errors: [],
       })
     ),


### PR DESCRIPTION
### Overview:概要
イベントの参加を取り消す cancelRegistration Action 時に、参加者が１ → ０人に変更された場合に、Participant reducer でエラーが発生する。
これはバックエンドから参加登録がないイベントのデータを取得した場合、participants をnormalize した entity は出力されない（entityオブジェクトにparticipantsプロパティがない）が、その存在しないプロパティにアクセスするためである。 
fetchEvent Action時には、participants プロパティが無ければ空のオブジェクトを設定している。
cancelRegistration Action 時にも fetchEvent Action と同様の処理を追加する。

### Technical changes:技術的変更点
- cancelRegistration Action 時に、entity に participants プロパティが無ければ空のオブジェクトを設定
- entity に participants プロパティが無い場合のテストケースを追加

### Impact point:変更に関する影響箇所
イベントの参加が取り消され、参加者が１ → ０人に変更された場合にエラーが発生せず、正常に動作する。

### Change of UserInterface:UIの変更
なし