### PR TITLE
Get auth info from window object on componentDidMount

### DIFF
--- a/pages/auth/callback.js
+++ b/pages/auth/callback.js
@@ -4,11 +4,24 @@ import Router from 'next/router'
 import { setAuthInfo, getAuthParams } from '../../utils/auth'
 import type { AuthInfo, AuthQueryParams } from '../../utils/auth'
 
-type Props = {
-  authInfo: AuthInfo,
+type Props = {}
+
+const getAuthInfoFrom = (queryStrings: String): AuthInfo => {
+  // Removing '?' in the head of string.
+  const query = queryStrings.slice(1).split('&').reduce((info, queryString) => {
+    const keyValue = queryString.split('=')
+    return Object.assign(info, { [keyValue[0]]: keyValue[1] })
+  }, {})
+
+  return {
+    accessToken: query.auth_token,
+    clientId: query.client_id,
+    uid: query.uid,
+  }
 }
 
 export default class AuthCallback extends Component<Props> {
+  // getInitialProps doesn't work when exported as static html.
   static async getInitialProps(ctx: { query: AuthQueryParams }) {
     return ctx.query ? {
       authInfo: getAuthParams(ctx.query),
@@ -16,7 +29,8 @@ export default class AuthCallback extends Component<Props> {
   }
 
   componentDidMount() {
-    setAuthInfo(this.props.authInfo)
+    const authInfo = getAuthInfoFrom(window.location.search)
+    setAuthInfo(authInfo)
     Router.replace('/')
   }
 


### PR DESCRIPTION
### Overview:概要
Github認証時に取得するトークンなどが後述の原因でlocalStorage に保存できず、ユーザー情報が取得できない事象へのとりあえずの対策です。

### Technical changes:技術的変更点
- 原因：
query string に含まれるトークンなどは、フロントエンドのサーバ上で getInitialProps メソッド実行時に取得する。しかし、Netlify へのデプロイ時には、静的なHTMLとしてexport するため、 getInitialProps は実行されない。

- 対策：
クライアント側で query string からトークンを取得する。
componentDidMount() メソッドで、  `window.location.search` プロパティから query string を取得。
必要なプロパティだけ抜き出したオブジェクトを作成する。

### Impact point:変更に関する影響箇所
getInitialProps メソッドの内容は変更しない。
（クライアント側では動いていないので、Netlify上の動作に影響はなし）

### Change of UserInterface:UIの変更
変更なし