### PR TITLE
Await setAuthInfo in auth callback page

### DIFF
--- a/pages/auth/callback.js
+++ b/pages/auth/callback.js
@@ -15,9 +15,9 @@ class AuthCallback extends Component<Props> {
     } : {}
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     const authInfo = getAuthParams(this.props.url.query)
-    setAuthInfo(authInfo)
+    await setAuthInfo(authInfo)
     Router.replace('/')
   }
 


### PR DESCRIPTION
### Overview:概要
現状では、Github 認証後にindex ページに戻った際に、アバターが表示されないことがあるので、その対策を行う。

### Technical changes:技術的変更点
対策： Github 認証後の、トークンなどのLocalStorage への保存処理の完了を、 await で待つ

Github認証後には、auth/callback Pageでトークン等を LocalStorage に保存し、index ページに遷移する。
LocalStorage へのアクセスは非同期なので、保存処理の完了前にindexページに遷移処理が実行された場合に、index ページでアバターが表示されない。
（保存処理自体は実行されるので、ページをリロードするとアバターが表示されるようになる）
そこで、await 構文で保存処理の完了を待ってからindexページに遷移することで、確実にアバターを表示させる。
ローカル環境で何度か認証を行い、その都度アバターが表示されることを確認した。
 
### Impact point:変更に関する影響箇所
Github 認証後のindex ページでアバターが表示されるようになる。

### Change of UserInterface:UIの変更
なし