### PR TITLE
Add Link component to new event link in index page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import Head from 'next/head';
+import Link from 'next/link'
 import Button from '@material/react-button';
 import TopAppBar from '@material/react-top-app-bar';
 import MaterialIcon from '@material/react-material-icon';
@@ -39,9 +40,11 @@ export default () => (
       <div className="home-list">
         <ul className="mdc-list">
           <li className="mdc-list-item">
-            <Button href="event/new">
-              <h1 className="mdc-typography--headline6">Create a new event</h1>
-            </Button>
+            <Link href="event/new">
+              <Button>
+                <h1 className="mdc-typography--headline6">Create a new event</h1>
+              </Button>
+            </Link>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
### Overview:概要
トップページの新規イベント作成のリンクが Page Not Found エラーとなることへの対応。

### Technical changes:技術的変更点
Nextjs の Link コンポーネントを削除し、通常のHTML の href 属性でイベント作成ページをリンク先に指定していることが原因。（対応する静的ページがＣＤＮ上にない）
以下の２つの対応があるが、クライアント側でレンダリングさせる 1番目の対応を行う。
- Nextjs のLink コンポーネントでイベント作成ページをリンク先に指定、Button 要素をラップする
- /event/new のエンドポイントにアクセスできるよう、ExportPathMap を追記して、イベント作成ページの静的ファイルを作成する

### Impact point:変更に関する影響箇所
イベント作成ページにアクセスできるようになる。

### Change of UserInterface:UIの変更
なし