### PR TITLE
Add Layout HOC to pages

### DIFF
--- a/components/Head/index.js
+++ b/components/Head/index.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react'
+import NextHead from 'next/head';
+
+const Head = () => (
+  <NextHead>
+    <link rel="stylesheet" href="/_next/static/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Rubik:300,400,500"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto+Mono"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700"
+    />
+  </NextHead>
+)
+
+export default Head

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react'
+import type { ComponentType } from 'react'
+import TopAppBar from '@material/react-top-app-bar'
+import MaterialIcon from '@material/react-material-icon'
+import UserInfo from '../UserInfo'
+import Head from '../Head';
+import '../../styles/style.css'
+
+type Props = {}
+
+const withLayout = (Component: ComponentType<*>) => (props: Props) => (
+  <div>
+    <Head />
+    <TopAppBar
+      title="Tebukuro"
+      navigationIcon={<MaterialIcon icon="thumb_up" />}
+      actionItems={[<UserInfo />]}
+    />
+    <div className="mdc-top-app-bar--fixed-adjust home-component">
+      <Component {...props} />
+    </div>
+  </div>
+)
+
+export default withLayout

--- a/pages/event/new.js
+++ b/pages/event/new.js
@@ -1,5 +1,8 @@
 // @flow
 import React from 'react'
 import EventRegistration from '../../containers/EventRegistration'
+import withLayout from '../../components/Layout'
 
-export default () => <EventRegistration />
+const NewEventPage = () => <EventRegistration />
+
+export default withLayout(NewEventPage)

--- a/pages/event/show.js
+++ b/pages/event/show.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import EventView from '../../containers/EventView'
+import withLayout from '../../components/Layout'
 import withQueryString from '../../components/QueryString'
 
 type Props = {
@@ -9,4 +10,4 @@ type Props = {
 
 const EventShowPage = (props: Props) => <EventView url={props.url} />
 
-export default withQueryString(EventShowPage)
+export default withLayout(withQueryString(EventShowPage))

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,53 +1,25 @@
 // @flow
-import React from 'react';
-import Head from 'next/head';
+import React from 'react'
 import Link from 'next/link'
-import Button from '@material/react-button';
-import TopAppBar from '@material/react-top-app-bar';
-import MaterialIcon from '@material/react-material-icon';
-import UserInfo from '../components/UserInfo';
-import '../styles/style.css';
+import Button from '@material/react-button'
+import withLayout from '../components/Layout'
 
-export default () => (
+const TopPage = () => (
   <div>
-    <Head>
-      <link rel="stylesheet" href="/_next/static/style.css" />
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/icon?family=Material+Icons"
-      />
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css?family=Rubik:300,400,500"
-      />
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css?family=Roboto+Mono"
-      />
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700"
-      />
-    </Head>
-    <TopAppBar
-      title="Tebukuro"
-      navigationIcon={<MaterialIcon icon="thumb_up" />}
-      actionItems={[<UserInfo />]}
-    />
-    <div className="mdc-top-app-bar--fixed-adjust home-component">
-      <h1 className="mdc-typography--headline2">Welcome to Tebukuro</h1>
+    <h1 className="mdc-typography--headline2">Welcome to Tebukuro</h1>
 
-      <div className="home-list">
-        <ul className="mdc-list">
-          <li className="mdc-list-item">
-            <Link href="event/new">
-              <Button>
-                <h1 className="mdc-typography--headline6">Create a new event</h1>
-              </Button>
-            </Link>
-          </li>
-        </ul>
-      </div>
+    <div className="home-list">
+      <ul className="mdc-list">
+        <li className="mdc-list-item">
+          <Link href="event/new">
+            <Button>
+              <h1 className="mdc-typography--headline6">Create a new event</h1>
+            </Button>
+          </Link>
+        </li>
+      </ul>
     </div>
   </div>
-);
+)
+
+export default withLayout(TopPage)


### PR DESCRIPTION
### Overview:概要
現在、トップページのみに表示されているTopAppBar を他のページにも表示する

### Technical changes:技術的変更点
- TopAppBar のComponent化し、Layout Component として独立
-  HOC化することで、`withLayout` で各ページのコンポーネントをラップして共有
 
### Impact point:変更に関する影響箇所
イベント作成、イベント詳細ページでもTopAppBarが表示される。

### Change of UserInterface:UIの変更
- イベント作成ページ
![screenshot from 2018-09-21 18-25-34](https://user-images.githubusercontent.com/10824691/45873036-7ba21d00-bdcc-11e8-967d-5fe430773900.png)

- イベント詳細ページ
![screenshot from 2018-09-21 18-24-52](https://user-images.githubusercontent.com/10824691/45873057-852b8500-bdcc-11e8-96f9-4f9fa03a4d93.png)

