### PR TITLE
Add material-components to Event show page

### DIFF
--- a/components/Event/__tests__/__snapshots__/EventComponent.spec.js.snap
+++ b/components/Event/__tests__/__snapshots__/EventComponent.spec.js.snap
@@ -2,29 +2,69 @@
 
 exports[`Event Component renders self. 1`] = `
 <div>
-  <p>
-    name: 
+  <h1
+    className="mdc-typography--headline3 event-name"
+  >
     event1
-  </p>
-  <p>
-    description: 
-    This is the first event.
-  </p>
-  <p>
-    quota: 
-    10
-  </p>
-  <p>
-    eventStartsAt: 
-    2018-03-01T09:00:00
-  </p>
-  <p>
-    eventEndsAt: 
-    2018-03-01T17:00:00
-  </p>
-  <p>
-    number of participants: 
+  </h1>
+  <ul
+    className="mdc-list"
+  >
+    <li
+      className="mdc-list-item"
+    >
+       
+      This is the first event.
+       
+    </li>
+  </ul>
+  <hr />
+  <h5
+    className="mdc-typography--headline5"
+  >
+    <MaterialIcon
+      hasRipple={false}
+      icon="access_time"
+    />
+     日時
+  </h5>
+  <ul
+    className="mdc-list"
+  >
+    <li
+      className="mdc-list-item"
+    >
+      <MaterialIcon
+        hasRipple={false}
+        icon="outlined_flag"
+      />
+      開始: 
+      2018-03-01T09:00:00
+    </li>
+    <li
+      className="mdc-list-item"
+    >
+      <MaterialIcon
+        hasRipple={false}
+        icon="flag"
+      />
+      終了: 
+      2018-03-01T17:00:00
+    </li>
+  </ul>
+  <hr />
+  <h5
+    className="mdc-typography--headline5"
+  >
+    <MaterialIcon
+      hasRipple={false}
+      icon="people"
+    />
+     参加者一覧 (
     3
-  </p>
+     / 
+    10
+     名)
+  </h5>
 </div>
 `;

--- a/components/Event/index.js
+++ b/components/Event/index.js
@@ -1,15 +1,30 @@
 // @flow
 import React from 'react'
+import MaterialIcon from '@material/react-material-icon'
 import type { EventProps } from '../../types/Event'
 
 const Event = (props: {event: EventProps}) => (
   <div>
-    <p>name: {props.event.name}</p>
-    <p>description: {props.event.description}</p>
-    <p>quota: {props.event.quota}</p>
-    <p>eventStartsAt: {props.event.eventStartsAt}</p>
-    <p>eventEndsAt: {props.event.eventEndsAt}</p>
-    <p>number of participants: {props.event.participants.length}</p>
+    <h1 className="mdc-typography--headline3 event-name" >{props.event.name}</h1>
+    <ul className="mdc-list">
+      <li className="mdc-list-item"> {props.event.description} </li>
+    </ul>
+    <hr />
+    <h5 className="mdc-typography--headline5"><MaterialIcon icon="access_time" /> 日時</h5>
+    <ul className="mdc-list">
+      <li className="mdc-list-item">
+        <MaterialIcon icon="outlined_flag" />
+        開始: {props.event.eventStartsAt}
+      </li>
+      <li className="mdc-list-item">
+        <MaterialIcon icon="flag" />
+        終了: {props.event.eventEndsAt}
+      </li>
+    </ul>
+    <hr />
+    <h5 className="mdc-typography--headline5">
+      <MaterialIcon icon="people" /> 参加者一覧 ({props.event.participants.length} / {props.event.quota} 名)
+    </h5>
   </div>
 )
 

--- a/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
+++ b/components/ParticipantsList/__tests__/__snapshots__/ParticipantListComponent.spec.js.snap
@@ -2,10 +2,17 @@
 
 exports[`ParticipantList Component renders self. 1`] = `
 <div>
-  <ul>
+  <ul
+    className="mdc-list"
+  >
     <li
+      className="mdc-list-item"
       key="1"
     >
+      <MaterialIcon
+        hasRipple={false}
+        icon="account_circle"
+      />
       <Participant
         eventId={1}
         id={1}
@@ -14,8 +21,13 @@ exports[`ParticipantList Component renders self. 1`] = `
       />
     </li>
     <li
+      className="mdc-list-item"
       key="2"
     >
+      <MaterialIcon
+        hasRipple={false}
+        icon="account_circle"
+      />
       <Participant
         eventId={1}
         id={2}

--- a/components/ParticipantsList/index.js
+++ b/components/ParticipantsList/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import MaterialIcon from '@material/react-material-icon'
 import ParticipantComponent from '../Participant'
 
 type Props = {
@@ -9,13 +10,14 @@ type Props = {
 const ParticipantsList = (props: Props) => (
   <div>
     { props.participants &&
-      <ul>
-        { props.participants.map(participant => (
-          <li key={participant.id}>
-            <ParticipantComponent {...participant} />
-          </li>
+    <ul className="mdc-list">
+      { props.participants.map(participant => (
+        <li className="mdc-list-item" key={participant.id}>
+          <MaterialIcon icon="account_circle" />
+          <ParticipantComponent {...participant} />
+        </li>
         ))}
-      </ul>
+    </ul>
     }
   </div>
 )

--- a/components/buttons/CancelRegistrationButton/__tests__/__snapshots__/CancelRegistrationButton.spec.js.snap
+++ b/components/buttons/CancelRegistrationButton/__tests__/__snapshots__/CancelRegistrationButton.spec.js.snap
@@ -1,9 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CancelRegistrationButton with event has a waitlist renders CancelRegistrationButton. 1`] = `
-<button
+<WithRipple(Button)
+  className=""
+  disabled={false}
+  icon={
+    <MaterialIcon
+      hasRipple={false}
+      icon="cancel"
+    />
+  }
+  initRipple={[Function]}
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  outlined={true}
+  raised={false}
+  style={Object {}}
+  unbounded={false}
+  unelevated={false}
 >
   登録をキャンセルする
-</button>
+</WithRipple(Button)>
 `;

--- a/components/buttons/CancelRegistrationButton/index.js
+++ b/components/buttons/CancelRegistrationButton/index.js
@@ -1,5 +1,7 @@
 // @flow
 import React from 'react'
+import Button from '@material/react-button'
+import MaterialIcon from '@material/react-material-icon'
 
 type Props = {
   eventId: ?number,
@@ -13,9 +15,13 @@ const CancelRegistrationButton = (props: Props) => {
   }
 
   return (
-    <button onClick={onClickHandler}>
+    <Button
+      icon={<MaterialIcon icon="cancel" />}
+      onClick={onClickHandler}
+      outlined
+    >
       登録をキャンセルする
-    </button>
+    </Button>
   )
 }
 

--- a/components/buttons/ParticipantButton/__tests__/__snapshots__/ParticipantButton.spec.js.snap
+++ b/components/buttons/ParticipantButton/__tests__/__snapshots__/ParticipantButton.spec.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ParticipantButton with event has a waitlist renders participant button with waitlited message. 1`] = `
-<button
-  onClick={[Function]}
->
-  キャンセル待ちに登録
-</button>
+<div>
+  <WaitlistedButton
+    onClick={[Function]}
+  />
+</div>
 `;
 
 exports[`ParticipantButton with event has no waitlist renders participant button with admit message. 1`] = `
-<button
-  onClick={[Function]}
->
-  参加登録
-</button>
+<div>
+  <RegisterButton
+    onClick={[Function]}
+  />
+</div>
 `;

--- a/components/buttons/ParticipantButton/index.js
+++ b/components/buttons/ParticipantButton/index.js
@@ -1,11 +1,33 @@
 // @flow
 import React from 'react'
+import Button from '@material/react-button'
+import MaterialIcon from '@material/react-material-icon'
 
 type Props = {
   eventId: ?number,
   hasEventWaitlist: boolean,
   onClick: Function,
 }
+
+const RegisterButton = (props: { onClick: Function }) => (
+  <Button
+    icon={<MaterialIcon icon="directions_walk" />}
+    onClick={props.onClick}
+    outlined
+  >
+    参加登録
+  </Button>
+)
+
+const WaitlistedButton = (props: { onClick: Function }) => (
+  <Button
+    icon={<MaterialIcon icon="playlist_add" />}
+    onClick={props.onClick}
+    outlined
+  >
+    キャンセル待ちに登録
+  </Button>
+)
 
 const ParticipantButton = (props: Props) => {
   const onClickHandler = (e: SyntheticEvent<>) => {
@@ -14,9 +36,12 @@ const ParticipantButton = (props: Props) => {
   }
 
   return (
-    <button onClick={onClickHandler}>
-      {props.hasEventWaitlist ? 'キャンセル待ちに登録' : '参加登録'}
-    </button>
+    <div>
+      {props.hasEventWaitlist ?
+        <WaitlistedButton onClick={onClickHandler} />
+          : <RegisterButton onClick={onClickHandler} />
+      }
+    </div>
   )
 }
 

--- a/containers/EventView.js
+++ b/containers/EventView.js
@@ -49,7 +49,6 @@ class EventView extends React.Component<Props> {
         <Error statusCode="404" />
         :
         <SessionProvider>
-          <h3>This is the event page!</h3>
           <EventComponent event={event} />
           <ParticipantFormComponent
             eventId={event.id}

--- a/styles/style.css
+++ b/styles/style.css
@@ -2420,3 +2420,6 @@ a {
   max-width: 100%;
   padding: 20px;
   margin: 0 auto; }
+
+.event-name {
+  background-color: #feeae6; }

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -37,3 +37,7 @@ a {
   padding: 20px;
   margin: 0 auto;
 }
+
+.event-name {
+  background-color: $mdc-theme-secondary;
+}


### PR DESCRIPTION
### Overview:概要
イベント詳細ページにmaterial-componentsを追加、マークアップのみの画面からとりあえず脱却したい。

### Technical changes:技術的変更点
- 画面デザインについては、スクリーンショットを参照
- Jest のスナップショットテストが変更となったため、更新

### Impact point:変更に関する影響箇所
なし

### Change of UserInterface:UIの変更
![screenshot from 2018-09-26 21-43-51](https://user-images.githubusercontent.com/10824691/46085146-4fc5d380-c1e0-11e8-8c9f-0f179d6684b0.png)

